### PR TITLE
Task02 Маргарита Михельсон МКН

### DIFF
--- a/src/phg/matching/descriptor_matcher.cpp
+++ b/src/phg/matching/descriptor_matcher.cpp
@@ -7,21 +7,28 @@ void phg::DescriptorMatcher::filterMatchesRatioTest(const std::vector<std::vecto
                                                     std::vector<cv::DMatch> &filtered_matches)
 {
     filtered_matches.clear();
-
-    throw std::runtime_error("not implemented yet");
+    for (int i = 0; i < (int)matches.size(); ++i) {
+        if (matches[i].size() < 1 || matches[i][0].distance / matches[i][1].distance < 0.6) {
+            filtered_matches.push_back(matches[i][0]);
+        }
+    }
 }
 
 
-void phg::DescriptorMatcher::filterMatchesClusters(const std::vector<cv::DMatch> &matches,
-                                                   const std::vector<cv::KeyPoint> keypoints_query,
-                                                   const std::vector<cv::KeyPoint> keypoints_train,
-                                                   std::vector<cv::DMatch> &filtered_matches)
+void phg::DescriptorMatcher::filterMatchesClusters(
+    const std::vector<cv::DMatch> &matches,
+    const std::vector<cv::KeyPoint> keypoints_query,
+    const std::vector<cv::KeyPoint> keypoints_train,
+    std::vector<cv::DMatch> &filtered_matches)
 {
     filtered_matches.clear();
 
-    const size_t  total_neighbours  = 5;  // total number of neighbours to test (including candidate)
-    const size_t  consistent_matches  = 3;  // minimum number of consistent matches (including candidate)
-    const float  radius_limit_scale  = 2.f;  // limit search radius by scaled median
+    const size_t  total_neighbours  = 5;
+    // total number of neighbours to test (including candidate)
+    const size_t  consistent_matches  = 3;
+    // minimum number of consistent matches (including candidate)
+    const float  radius_limit_scale  = 2.f;
+    // limit search radius by scaled median
 
     const int n_matches = matches.size();
 
@@ -35,42 +42,67 @@ void phg::DescriptorMatcher::filterMatchesClusters(const std::vector<cv::DMatch>
         points_query.at<cv::Point2f>(i) = keypoints_query[matches[i].queryIdx].pt;
         points_train.at<cv::Point2f>(i) = keypoints_train[matches[i].trainIdx].pt;
     }
-//
-//    // размерность всего 2, так что точное KD-дерево
-//    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(TODO);
-//    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(TODO);
-//
-//    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
-//    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
-//
-//    // для каждой точки найти total neighbors ближайших соседей
-//    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
-//    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
-//
-//    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
-//    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
-//
-//    // оценить радиус поиска для каждой картинки
-//    // NB: radius2_query, radius2_train: квадраты радиуса!
-//    float radius2_query, radius2_train;
-//    {
-//        std::vector<double> max_dists2_query(n_matches);
-//        std::vector<double> max_dists2_train(n_matches);
-//        for (int i = 0; i < n_matches; ++i) {
-//            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
-//            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
-//        }
-//
-//        int median_pos = n_matches / 2;
-//        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
-//        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
-//
-//        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
-//        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
-//    }
-//
-//    метч остается, если левое и правое множества первых total_neighbors соседей в радиусах поиска(radius2_query, radius2_train) имеют как минимум consistent_matches общих элементов
-//    // TODO заполнить filtered_matches
+
+    // размерность всего 2, так что точное KD-дерево
+    std::shared_ptr<cv::flann::IndexParams> index_params =
+            flannKdTreeIndexParams(1);
+    std::shared_ptr<cv::flann::SearchParams> search_params =
+            flannKsTreeSearchParams(50);
+
+    std::shared_ptr<cv::flann::Index> index_query =
+            flannKdTreeIndex(points_query, index_params);
+    std::shared_ptr<cv::flann::Index> index_train =
+            flannKdTreeIndex(points_train, index_params);
+
+    // для каждой точки найти total neighbors ближайших соседей
+    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
+    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
+
+    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
+    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
+
+    // оценить радиус поиска для каждой картинки
+    // NB: radius2_query, radius2_train: квадраты радиуса!
+    float radius2_query, radius2_train;
+    {
+        std::vector<double> max_dists2_query(n_matches);
+        std::vector<double> max_dists2_train(n_matches);
+        for (int i = 0; i < n_matches; ++i) {
+            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours-1);
+            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours-1);
+        }
+
+        int median_pos = n_matches / 2;
+        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
+        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
+
+        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
+        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
+    }
+
+//    матч остается, если левое и правое множества первых total_neighbors соседей в радиусах поиска(radius2_query, radius2_train) имеют как минимум consistent_matches общих элементов
+    // TODO заполнить filtered_matches
+    for (int i = 0; i < n_matches; i++) {
+        std::vector<int> close_q;
+        for (int j = 0; j < total_neighbours; j++) {
+            if (distances2_query.at<float>(i, j) <= radius2_query) {
+                close_q.push_back(indices_query.at<int>(i, j));
+            }
+        }
+        int good_cnt = 0;
+        for (int j = 0; j < total_neighbours; j++) {
+            if (distances2_train.at<float>(i, j) <= radius2_train) {
+                int idx = indices_train.at<int>(i, j);
+                for (int t = 0; t < (int)close_q.size(); t++) {
+                    if (close_q[t] == idx) good_cnt++;
+                }
+            }
+        }
+
+        if (good_cnt >= consistent_matches) {
+            filtered_matches.push_back(matches[i]);
+        }
+    }
 }

--- a/src/phg/matching/flann_matcher.cpp
+++ b/src/phg/matching/flann_matcher.cpp
@@ -6,8 +6,9 @@
 phg::FlannMatcher::FlannMatcher()
 {
     // параметры для приближенного поиска
-//    index_params = flannKdTreeIndexParams(TODO);
-//    search_params = flannKsTreeSearchParams(TODO);
+    // TODO
+    index_params = flannKdTreeIndexParams(2);
+    search_params = flannKsTreeSearchParams(70);
 }
 
 void phg::FlannMatcher::train(const cv::Mat &train_desc)
@@ -17,5 +18,14 @@ void phg::FlannMatcher::train(const cv::Mat &train_desc)
 
 void phg::FlannMatcher::knnMatch(const cv::Mat &query_desc, std::vector<std::vector<cv::DMatch>> &matches, int k) const
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Mat indices, dists;
+    flann_index->knnSearch(query_desc, indices, dists, k, *search_params);
+
+    for (int i = 0; i < query_desc.rows; i++) {
+        std::vector<cv::DMatch> curr_matches;
+        for (int j = 0; j < k; j++) {
+            curr_matches.push_back(cv::DMatch(i, indices.at<int>(i, j), dists.at<float>(i, j)));
+        }
+        matches.push_back(curr_matches);
+    }
 }

--- a/src/phg/matching/flann_matcher.cpp
+++ b/src/phg/matching/flann_matcher.cpp
@@ -8,7 +8,7 @@ phg::FlannMatcher::FlannMatcher()
     // параметры для приближенного поиска
     // TODO
     index_params = flannKdTreeIndexParams(2);
-    search_params = flannKsTreeSearchParams(70);
+    search_params = flannKsTreeSearchParams(60);
 }
 
 void phg::FlannMatcher::train(const cv::Mat &train_desc)

--- a/src/phg/sfm/homography.cpp
+++ b/src/phg/sfm/homography.cpp
@@ -84,8 +84,16 @@ namespace {
             double w1 = ws1[i];
 
             // 8 elements of matrix + free term as needed by gauss routine
-//            A.push_back({TODO});
-//            A.push_back({TODO});
+            A.push_back({
+                    0.0, 0.0, 0.0,
+                    -w1*x0, -w1*y0, -w1*w0,
+                    y1*x0, y1*y0, -y1*w0
+            });
+            A.push_back({
+                    w1*x0, w1*y0, w1*w0,
+                    0.0, 0.0, 0.0,
+                    -x1*x0, -x1*y0, x1*w0
+            });
         }
 
         int res = gauss(A, H);
@@ -94,7 +102,7 @@ namespace {
         }
         else
         if (res == 1) {
-//            std::cout << "gauss: unique solution found" << std::endl;
+            //std::cout << "gauss: unique solution found" << std::endl;
         }
         else
         if (res == std::numeric_limits<int>::max()) {
@@ -168,57 +176,61 @@ namespace {
         // * (простое описание для понимания)
         // * [3] http://ikrisoft.blogspot.com/2015/01/ransac-with-contrario-approach.html
 
-//        const int n_matches = points_lhs.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        const int n_trials = TODO;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//        const double reprojection_error_threshold_px = 2;
-//
-//        int best_support = 0;
-//        cv::Mat best_H;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            randomSample(sample, n_matches, n_samples, &seed);
-//
-//            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
-//                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
-//
-//            int support = 0;
-//            for (int i_point = 0; i_point < n_matches; ++i_point) {
-//                try {
-//                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
-//                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
-//                        ++support;
-//                    }
-//                } catch (const std::exception &e)
-//                {
-//                    std::cerr << e.what() << std::endl;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_H = H;
-//
-//                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
-//
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
-//        }
-//
-//        return best_H;
+        const int n_matches = points_lhs.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        const int n_trials = 50;
+
+        const int n_samples = 4;
+        uint64_t seed = 1;
+        const double reprojection_error_threshold_px = 2;
+
+        int best_support = 0;
+        cv::Mat best_H;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            randomSample(sample, n_matches, n_samples, &seed);
+
+            cv::Mat H = estimateHomography4Points(
+                    points_lhs[sample[0]], points_lhs[sample[1]],
+                    points_lhs[sample[2]], points_lhs[sample[3]],
+                    points_rhs[sample[0]], points_rhs[sample[1]],
+                    points_rhs[sample[2]], points_rhs[sample[3]]
+            );
+
+            int support = 0;
+            for (int i_point = 0; i_point < n_matches; ++i_point) {
+                try {
+                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
+                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
+                        ++support;
+                    }
+                } catch (const std::exception &e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_H = H;
+
+                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
+        }
+
+        return best_H;
     }
 
 }
@@ -238,7 +250,10 @@ cv::Mat phg::findHomographyCV(const std::vector<cv::Point2f> &points_lhs, const 
 // таким преобразованием внутри занимается функции cv::perspectiveTransform и cv::warpPerspective
 cv::Point2d phg::transformPoint(const cv::Point2d &pt, const cv::Mat &T)
 {
-    throw std::runtime_error("not implemented yet");
+    double data[3][1] = {{pt.x}, {pt.y}, {1.0}};
+    cv::Mat transformed = T * cv::Mat(3, 1, CV_64F, data);
+    double z = transformed.at<double>(2, 0);
+    return cv::Point2d(transformed.at<double>(0,0)/z, transformed.at<double>(1,0)/z);
 }
 
 cv::Point2d phg::transformPointCV(const cv::Point2d &pt, const cv::Mat &T) {

--- a/src/phg/sfm/panorama_stitcher.cpp
+++ b/src/phg/sfm/panorama_stitcher.cpp
@@ -10,6 +10,35 @@
  *          этот список образует дерево, корень дерева (картинка, которая ни к кому не приклеивается, приклеиваются только к ней), в данном массиве имеет значение -1
  * homography_builder - функтор, возвращающий гомографию по паре картинок
  * */
+
+void dfs(
+    int i,
+    std::vector<cv::Mat>&Hs,
+    const std::vector<int> &parent,
+    std::vector<bool> &done,
+    const std::vector<cv::Mat> &imgs,
+    std::function<cv::Mat(const cv::Mat &, const cv::Mat &)> &homography_builder)
+{
+    if (done[i]) {
+        return;
+    }
+    done[i] = true;
+
+    int p = parent[i];
+    if (p < 0) {
+        Hs[i] = cv::Mat::eye(3, 3, CV_64F);
+        return;
+    }
+    dfs(p, Hs, parent, done, imgs, homography_builder);
+    Hs[i] = Hs[p] * homography_builder(imgs[i], imgs[p]);
+}
+
+
+cv::Point2d applyH(cv::Point2d pt, cv::Mat &h) {
+    return phg::transformPoint(pt, h.inv());
+}
+
+
 cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
                             const std::vector<int> &parent,
                             std::function<cv::Mat(const cv::Mat &, const cv::Mat &)> &homography_builder)
@@ -20,10 +49,14 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
 
     // вектор гомографий, для каждой картинки описывает преобразование до корня
     std::vector<cv::Mat> Hs(n_images);
+    std::vector<bool> done(n_images, false);
     {
+        for (int i = 0; i < n_images; i++) {
+            dfs(i, Hs, parent, done, imgs, homography_builder);
+        }
         // здесь надо посчитать вектор Hs
         // при этом можно обойтись n_images - 1 вызовами функтора homography_builder
-        throw std::runtime_error("not implemented yet");
+        //throw std::runtime_error("not implemented yet");
     }
 
     bbox2<double, cv::Point2d> bbox;
@@ -46,19 +79,19 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
     // из-за растяжения пикселей при использовании прямой матрицы гомографии после отображения между пикселями остается пустое пространство
     // лучше использовать обратную и для каждого пикселя на итоговвой картинке проверять, с какой картинки он может получить цвет
     // тогда в некоторых пикселях цвет будет дублироваться, но изображение будет непрерывным
-//        for (int i = 0; i < n_images; ++i) {
-//            for (int y = 0; y < imgs[i].rows; ++y) {
-//                for (int x = 0; x < imgs[i].cols; ++x) {
-//                    cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
-//
-//                    cv::Point2d pt_dst = applyH(cv::Point2d(x, y), Hs[i]) - bbox.min();
-//                    int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
-//                    int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
-//
-//                    result.at<cv::Vec3b>(y_dst, x_dst) = color;
-//                }
-//            }
-//        }
+        for (int i = 0; i < n_images; ++i) {
+            for (int y = 0; y < imgs[i].rows; ++y) {
+                for (int x = 0; x < imgs[i].cols; ++x) {
+                    cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
+
+                    cv::Point2d pt_dst = applyH(cv::Point2d(x, y), Hs[i]) - bbox.min();
+                    int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
+                    int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
+
+                    result.at<cv::Vec3b>(y_dst, x_dst) = color;
+                }
+            }
+        }
 
     std::vector<cv::Mat> Hs_inv;
     std::transform(Hs.begin(), Hs.end(), std::back_inserter(Hs_inv), [&](const cv::Mat &H){ return H.inv(); });

--- a/src/phg/sfm/panorama_stitcher.cpp
+++ b/src/phg/sfm/panorama_stitcher.cpp
@@ -35,7 +35,7 @@ void dfs(
 
 
 cv::Point2d applyH(cv::Point2d pt, cv::Mat &h) {
-    return phg::transformPoint(pt, h.inv());
+    return phg::transformPoint(pt, h);
 }
 
 

--- a/tests/test_matching.cpp
+++ b/tests/test_matching.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
@@ -13,6 +14,7 @@
 #include <libutils/timer.h>
 #include <phg/sfm/panorama_stitcher.h>
 #include <phg/matching/gms_matcher.h>
+#include <stdexcept>
 
 
 #include "utils/test_utils.h"
@@ -20,7 +22,7 @@
 
 // TODO enable both toggles for testing custom detector & matcher
 #define ENABLE_MY_DESCRIPTOR 0
-#define ENABLE_MY_MATCHING 0
+#define ENABLE_MY_MATCHING 1
 #define ENABLE_GPU_BRUTEFORCE_MATCHER 0
 
 #if ENABLE_MY_MATCHING

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -31,7 +31,7 @@ void drawKeyPoints(cv::Mat &img, const std::vector<cv::KeyPoint> &kps, const std
         int thickness = 1;
         cv::Scalar color;
         if (is_not_matched[i]) {
-            color = CV_RGB(255, 0, 0); // OpenCV использует BGR схему вместо RGB, но можно использовать этот макрос вместо BGR - cv::Scalar(blue=0, green=0, red=255)  
+            color = CV_RGB(255, 0, 0); // OpenCV использует BGR схему вместо RGB, но можно использовать этот макрос вместо BGR - cv::Scalar(blue=0, green=0, red=255)
             thickness = 2;
         } else {
             color = cv::Scalar(r.uniform(0, 255), r.uniform(0, 255), 0);
@@ -75,7 +75,7 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
 
     ASSERT_FALSE(img0.empty()); // проверка что картинка была загружена
     // убедитесь что рабочая папка (Edit Configurations...->Working directory) указывает на корневую папку проекта (и тогда картинка по умолчанию найдется по относительному пути - data/src/test_sift/unicorn.png)
-    
+
     size_t width = img0.cols;
     size_t height = img0.rows;
     cv::Mat transformedImage;
@@ -119,18 +119,17 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                 detector->compute(img1, kps1, desc1);
             } else if (method == 2) {
                 // TODO remove 'return' and uncomment
-                return;
-//                method_name = "SIFT_MY";
-//                log_prefix = "[SIFT_MY] ";
-//                phg::SIFT mySIFT;
-//                mySIFT.detectAndCompute(img0, kps0, desc0);
-//                mySIFT.detectAndCompute(img1, kps1, desc1);
+                method_name = "SIFT_MY";
+                log_prefix = "[SIFT_MY] ";
+                phg::SIFT mySIFT;
+                mySIFT.detectAndCompute(img0, kps0, desc0);
+                mySIFT.detectAndCompute(img1, kps1, desc1);
             } else {
                 rassert(false, 13532513412); // это не проверка как часть тестирования, это проверка что число итераций в цикле и if-else ветки все еще согласованы и не разошлись
             }
 
             std::cout << log_prefix << "Points detected: " << kps0.size() << " -> " << kps1.size() << " (in " << t.elapsed() << " sec)" << std::endl;
-    
+
             std::vector<cv::Point2f> ps01(kps0.size()); // давайте построим эталон - найдем куда бы должны были сместиться ключевые точки с исходного изображения с учетом нашей матрицы трансформации M
             {
                 std::vector<cv::Point2f> ps0(kps0.size()); // здесь мы сейчас расположим детектированные ключевые точки (каждую нужно преобразовать из типа КлючеваяТочка в Точка2Дэ)
@@ -162,7 +161,7 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                     continue;
                 }
 
-                ptrdiff_t closest_j = -1; // будем искать ближайшую точку детектированную на искаженном изображении 
+                ptrdiff_t closest_j = -1; // будем искать ближайшую точку детектированную на искаженном изображении
                 double min_error = std::numeric_limits<float>::max();
                 for (ptrdiff_t j = 0; j < kps1.size(); ++j) {
                     double error = cv::norm(kps1[j].pt - p01);
@@ -194,7 +193,7 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                         desc_rand_dist_sum += cv::norm(d0, random_d1, cv::NORM_L2);
 
                         desc_dist_sum += cv::norm(d0, d1, cv::NORM_L2);
-                        
+
                         // Это способ заглянуть в черную коробку, так вы можете визуально посмотреть на то
                         // что за числа в дескрипторах двух сопоставленных точек, насколько они похожи,
                         // и сверить что расстояние между дескрипторами - это действительно расстояние
@@ -244,7 +243,7 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
             // где проблемы, или где можно что-то улучшить
             drawKeyPoints(result0, kps0, is_not_matched0);
             drawKeyPoints(result1, kps1, is_not_matched1);
-    
+
             cv::Mat result = concatenateImagesLeftRight(result0, result1);
             cv::putText(result, log_prefix + " recall=" + to_string(recall), cv::Point(10, 30), cv::FONT_HERSHEY_DUPLEX, 0.75, CV_RGB(255, 255, 0));
             cv::putText(result, "avgPixelsError=" + to_string(avg_error), cv::Point(10, 60), cv::FONT_HERSHEY_DUPLEX, 0.75, CV_RGB(255, 255, 0));


### PR DESCRIPTION
1) Зачем фильтровать матчи, если потом мы запускаем устойчивый к выбросам RANSAC и отфильтровываем шумные сопоставления?

> Чем меньше шумных матчей, тем быстрее RANSAC найдет правильную гомографию (больше вероятность выбрать 4 матча-инлаера). Плюс, шумные матчи могут голосовать за неверные гипотезы, так что чем больше шумных матчей, тем сложнее отделить правильную гипотезу от ложной 

2) Cluster filtering довольно хорошо работает и без Ratio test. Однако, если оставить только Cluster filtering, некоторые тесты начнут падать. Почему так происходит? В каких случаях наоборот, не хватает Ratio test и необходима дополнительная фильтрация?

> Допустим на картинке есть повторяющийся фрагмент. Тогда целая группа точек может заматчится на неправильный фрагмент, но они все пройдут cluster filtering (на одной из картинок как раз есть три очень близкие фичи, которые матчатся совершенно не туда куда надо, но проходят cluster filtering). А вот ratio test в таких ситуациях помогает, потому что если фича одинаково хорошо матчится в два разных места, она отбросится. 
Ratio test, наоборот, оставляет разрозненные шумные матчи, просто потому что условная вершина горы с одного кадра хорошо заматчилась на совершенно другую вершину со второго кадра.

3) С какой проблемой можно столкнуться при приравнивании единице элемента H33 матрицы гомографии? Как ее решить?

> Может статься, что H33 = 0 (такая гомография переводит в бесконечно удаленную некоторую прямую, проходящую через (0, 0) ).  Заметим что в таком случае либо Н32 можно принять за 1, либо же Н32 = 0, и тогда за 1 можно считать Н31. В случае когда вся третья строка матрицы гомографии равна нулю, гомография получается вырожденной (все переходит в бесконечно удаленную прямую), такой случай нас не интересует. 
То есть мы все так же будем решать систему линейных уравнений, только в трех вариантах: 
— Н33 = 1
— Н33 = 0, Н32 = 1
— Н33 = Н32 = 0, Н31 = 1

4) Какой подвох таится в попытке склеивать большие панорамы и ортофото методом, реализованным в данной домашке? (Для интуиции можно посмотреть на результат склейки, когда за корень взята какая-нибудь другая картинка)

> Чем больше панорама, тем меньше гомографии крайних картинок похожи на тождественное преобразование => тем сильнее картинки растягиваются, и тем меньше точности приходится на пиксель получившегося изображения

5) Как можно автоматически построить граф для построения панорамы, чтобы на вход метод принимал только список картинок?

> Можно заматчить все пары картинок, получится полный граф, на гранях которого написано количество матчей. Выделяем из этого графа остовное дерево с максимальным весом ребер, и уже по нему считаем гомографии и склеиваем панораму. 
Если про картинки известна дополнительная информация, например примерное положение дрона, можно выбрать остовное дерево, минимизирующее расстояние между этими положениями