### PR TITLE
Task03 Вячеслав Тамарин СПбГУ МКН

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(OpenCV 4.5.1 REQUIRED)
 #     Windows: (но рекомендуется использовать Linux)
 # Скачайте этот скрипт и следуйте инструкции - https://gist.github.com/PolarNick239/18036d942ae4b9aad9f1da756ce6c845#file-buildocv-sh-L10-L33
 
-find_package(Eigen3 3.3 REQUIRED)
+find_package(Eigen3 3.4 REQUIRED)
 #      Linux:
 # sudo apt install libeigen3-dev
 #      Windows (чтобы удобно копировать в Git Bash консоль: выделите, нажмите Ctrl+C, в консоли нажмите Shift+Insert):

--- a/src/phg/matching/descriptor_matcher.cpp
+++ b/src/phg/matching/descriptor_matcher.cpp
@@ -8,69 +8,105 @@ void phg::DescriptorMatcher::filterMatchesRatioTest(const std::vector<std::vecto
 {
     filtered_matches.clear();
 
-    throw std::runtime_error("not implemented yet");
+    for (auto match: matches) {
+        if (match.size() == 0 || match[0].distance / match[1].distance < 0.6) {
+            filtered_matches.push_back(match[0]);
+        }
+    }
 }
 
+void filterNeighbours(const int total_neighbours,
+                      const int center,
+                      const float radius,
+                      const cv::Mat &distance2,
+                      const cv::Mat &indices,
+                      std::vector<int> &neighbours
+                      ) {
+    for (int i = 0; i < total_neighbours; i++) {
+        if (distance2.at<float>(center, i) <= radius) {
+            neighbours.push_back(indices.at<int>(center, i));
+        }
+    }
+}
 
 void phg::DescriptorMatcher::filterMatchesClusters(const std::vector<cv::DMatch> &matches,
                                                    const std::vector<cv::KeyPoint> keypoints_query,
                                                    const std::vector<cv::KeyPoint> keypoints_train,
                                                    std::vector<cv::DMatch> &filtered_matches)
 {
-    filtered_matches.clear();
+     filtered_matches.clear();
 
-    const size_t  total_neighbours  = 5;  // total number of neighbours to test (including candidate)
-    const size_t  consistent_matches  = 3;  // minimum number of consistent matches (including candidate)
-    const float  radius_limit_scale  = 2.f;  // limit search radius by scaled median
+     const size_t  total_neighbours  = 5;  // total number of neighbours to test (including candidate)
+     const size_t  consistent_matches  = 3;  // minimum number of consistent matches (including candidate)
+     const float  radius_limit_scale  = 2.f;  // limit search radius by scaled median
 
-    const int n_matches = matches.size();
+     const int n_matches = matches.size();
 
-    if (n_matches < total_neighbours) {
-        throw std::runtime_error("DescriptorMatcher::filterMatchesClusters : too few matches");
-    }
+     if (n_matches < total_neighbours) {
+         throw std::runtime_error("DescriptorMatcher::filterMatchesClusters : too few matches");
+     }
 
-    cv::Mat points_query(n_matches, 2, CV_32FC1);
-    cv::Mat points_train(n_matches, 2, CV_32FC1);
-    for (int i = 0; i < n_matches; ++i) {
-        points_query.at<cv::Point2f>(i) = keypoints_query[matches[i].queryIdx].pt;
-        points_train.at<cv::Point2f>(i) = keypoints_train[matches[i].trainIdx].pt;
-    }
-//
-//    // размерность всего 2, так что точное KD-дерево
-//    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(TODO);
-//    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(TODO);
-//
-//    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
-//    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
-//
-//    // для каждой точки найти total neighbors ближайших соседей
-//    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
-//    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
-//
-//    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
-//    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
-//
-//    // оценить радиус поиска для каждой картинки
-//    // NB: radius2_query, radius2_train: квадраты радиуса!
-//    float radius2_query, radius2_train;
-//    {
-//        std::vector<double> max_dists2_query(n_matches);
-//        std::vector<double> max_dists2_train(n_matches);
-//        for (int i = 0; i < n_matches; ++i) {
-//            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
-//            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
-//        }
-//
-//        int median_pos = n_matches / 2;
-//        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
-//        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
-//
-//        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
-//        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
-//    }
-//
+     cv::Mat points_query(n_matches, 2, CV_32FC1);
+     cv::Mat points_train(n_matches, 2, CV_32FC1);
+     for (int i = 0; i < n_matches; ++i) {
+         points_query.at<cv::Point2f>(i) = keypoints_query[matches[i].queryIdx].pt;
+         points_train.at<cv::Point2f>(i) = keypoints_train[matches[i].trainIdx].pt;
+     }
+
+     // размерность всего 2, так что точное KD-дерево
+     std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(1);
+     std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(50);
+
+     std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
+     std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
+
+     // для каждой точки найти total neighbors ближайших соседей
+     cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
+     cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
+     cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
+     cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
+
+     index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
+     index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
+
+     // оценить радиус поиска для каждой картинки
+     // NB: radius2_query, radius2_train: квадраты радиуса!
+     float radius2_query, radius2_train;
+     {
+         std::vector<double> max_dists2_query(n_matches);
+         std::vector<double> max_dists2_train(n_matches);
+         for (int i = 0; i < n_matches; ++i) {
+             max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
+             max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
+         }
+
+         int median_pos = n_matches / 2;
+         std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
+         std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
+
+         radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
+         radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
+     }
+
 //    метч остается, если левое и правое множества первых total_neighbors соседей в радиусах поиска(radius2_query, radius2_train) имеют как минимум consistent_matches общих элементов
 //    // TODO заполнить filtered_matches
+    for (int center = 0; center < n_matches; center++) {
+        std::vector<int> query_neighbours;
+        filterNeighbours(total_neighbours, center, radius2_query, distances2_query, indices_query, query_neighbours);
+        std::vector<int> train_neighbours;
+        filterNeighbours(total_neighbours, center, radius2_train, distances2_train, indices_train, train_neighbours);
+
+        std::vector<int> intersection;
+        std::set_intersection(
+                query_neighbours.begin(),
+                query_neighbours.end(),
+                train_neighbours.begin(),
+                train_neighbours.end(),
+                std::back_inserter(intersection)
+                );
+        int intersection_size = intersection.size();
+        if (intersection_size >= consistent_matches) {
+            filtered_matches.push_back(matches[center]);
+        }
+    }
 }

--- a/src/phg/matching/flann_matcher.cpp
+++ b/src/phg/matching/flann_matcher.cpp
@@ -6,8 +6,8 @@
 phg::FlannMatcher::FlannMatcher()
 {
     // параметры для приближенного поиска
-//    index_params = flannKdTreeIndexParams(TODO);
-//    search_params = flannKsTreeSearchParams(TODO);
+    index_params = flannKdTreeIndexParams(4);
+    search_params = flannKsTreeSearchParams(32);
 }
 
 void phg::FlannMatcher::train(const cv::Mat &train_desc)
@@ -17,5 +17,13 @@ void phg::FlannMatcher::train(const cv::Mat &train_desc)
 
 void phg::FlannMatcher::knnMatch(const cv::Mat &query_desc, std::vector<std::vector<cv::DMatch>> &matches, int k) const
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Mat indices, dists;
+    flann_index->knnSearch(query_desc, indices, dists, k, *search_params);
+    for (int i = 0; i < query_desc.rows; i++) {
+        std::vector<cv::DMatch> match;
+        for (int j = 0; j < k; j++) {
+            match.push_back(cv::DMatch(i, indices.at<int>(i, j), dists.at<float>(i, j)));
+        }
+        matches.push_back(match);
+    }
 }

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -18,8 +18,11 @@ namespace {
         copy(Ecv, E);
 
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-        throw std::runtime_error("not implemented yet");
-// TODO
+        Eigen::VectorXd singular_values = svd.singularValues().col(0);
+        singular_values(1) = singular_values(0);
+        singular_values(2) = 0;
+
+        E = svd.matrixU() * singular_values.asDiagonal() * svd.matrixV();
 
         copy(E, Ecv);
     }
@@ -28,12 +31,9 @@ namespace {
 
 cv::Matx33d phg::fmatrix2ematrix(const cv::Matx33d &F, const phg::Calibration &calib0, const phg::Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    matrix3d E = TODO;
-//
-//    ensureSpectralProperty(E);
-//
-//    return E;
+    matrix3d E = calib1.K().t() * F * calib0.K();
+    ensureSpectralProperty(E);
+    return E;
 }
 
 namespace {
@@ -61,21 +61,20 @@ namespace {
 
     bool depthTest(const vector2d &m0, const vector2d &m1, const phg::Calibration &calib0, const phg::Calibration &calib1, const matrix34d &P0, const matrix34d &P1)
     {
-        throw std::runtime_error("not implemented yet");
-//        // скомпенсировать калибровки камер
-//        vector3d p0 = TODO;
-//        vector3d p1 = TODO;
-//
-//        vector3d ps[2] = {p0, p1};
-//        matrix34d Ps[2] = {P0, P1};
-//
-//        vector4d X = phg::triangulatePoint(Ps, ps, 2);
-//        if (X[3] != 0) {
-//            X /= X[3];
-//        }
-//
-//        // точка должна иметь положительную глубину для обеих камер
-//        return TODO && TODO;
+        // скомпенсировать калибровки камер
+        vector3d p0 = calib0.unproject(m0);
+        vector3d p1 = calib0.unproject(m1);
+
+        vector3d ps[2] = {p0, p1};
+        matrix34d Ps[2] = {P0, P1};
+
+        vector4d X = phg::triangulatePoint(Ps, ps, 2);
+        if (X[3] != 0) {
+            X /= X[3];
+        }
+
+        // точка должна иметь положительную глубину для обеих камер
+        return calib0.project(P0*X)[2] > 0 && calib1.project(P1*X)[2] > 0;
     }
 }
 
@@ -88,80 +87,85 @@ namespace {
 // первичное разложение существенной матрицы (а из него, взаимное расположение камер) для последующего уточнения методом нелинейной оптимизации
 void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &Ecv, const std::vector<cv::Vec2d> &m0, const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    if (m0.size() != m1.size()) {
-//        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
-//    }
-//
-//    using mat = Eigen::MatrixXd;
-//    using vec = Eigen::VectorXd;
-//
-//    mat E;
-//    copy(Ecv, E);
-//
-//    // (см. Hartley & Zisserman p.258)
-//
-//    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//    mat U = svd.matrixU();
-//    vec s = svd.singularValues();
-//    mat V = svd.matrixV();
-//
-//    // U, V must be rotation matrices, not just orthogonal
-//    if (U.determinant() < 0) U = -U;
-//    if (V.determinant() < 0) V = -V;
-//
-//    std::cout << "U:\n" << U << std::endl;
-//    std::cout << "s:\n" << s << std::endl;
-//    std::cout << "V:\n" << V << std::endl;
-//
-//
-//    mat R0 = TODO;
-//    mat R1 = TODO;
-//
-//    std::cout << "R0:\n" << R0 << std::endl;
-//    std::cout << "R1:\n" << R1 << std::endl;
-//
-//    vec t0 = TODO;
-//    vec t1 = TODO;
-//
-//    std::cout << "t0:\n" << t0 << std::endl;
-//
-//    P0 = matrix34d::eye();
-//
-//    // 4 possible solutions
-//    matrix34d P10 = composeP(R0, t0);
-//    matrix34d P11 = composeP(R0, t1);
-//    matrix34d P12 = composeP(R1, t0);
-//    matrix34d P13 = composeP(R1, t1);
-//    matrix34d P1s[4] = {P10, P11, P12, P13};
-//
-//    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
-//    int best_count = 0;
-//    int best_idx = -1;
-//    for (int i = 0; i < 4; ++i) {
-//        int count = 0;
-//        for (int j = 0; j < (int) m0.size(); ++j) {
-//            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
-//                ++count;
-//            }
-//        }
-//        std::cout << "decomposeEMatrix: count: " << count << std::endl;
-//        if (count > best_count) {
-//            best_count = count;
-//            best_idx = i;
-//        }
-//    }
-//
-//    if (best_count == 0) {
-//        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
-//    }
-//
-//    P1 = P1s[best_idx];
-//
-//    std::cout << "best idx: " << best_idx << std::endl;
-//    std::cout << "P0: \n" << P0 << std::endl;
-//    std::cout << "P1: \n" << P1 << std::endl;
+    if (m0.size() != m1.size()) {
+        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
+    }
+
+    using mat = Eigen::MatrixXd;
+    using vec = Eigen::VectorXd;
+
+    mat E;
+    copy(Ecv, E);
+
+    // (см. Hartley & Zisserman p.258)
+
+    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+    mat U = svd.matrixU();
+    vec s = svd.singularValues();
+    mat V = svd.matrixV();
+
+    // U, V must be rotation matrices, not just orthogonal
+    if (U.determinant() < 0) U = -U;
+    if (V.determinant() < 0) V = -V;
+
+    std::cout << "U:\n" << U << std::endl;
+    std::cout << "s:\n" << s << std::endl;
+    std::cout << "V:\n" << V << std::endl;
+
+    Eigen::Matrix3d W = Eigen::Matrix3d::Zero();
+    W(1, 0) = 1;
+    W(0, 1) = -1;
+    W(2, 2) = 1;
+
+    mat R0 = U*W*V.transpose();
+    mat R1 = U*W.transpose()*V.transpose();
+
+    std::cout << "R0:\n" << R0 << std::endl;
+    std::cout << "R1:\n" << R1 << std::endl;
+
+    vec t0(3);
+    t0 << U(0, 2), U(1, 2), U(2, 2);
+    vec t1(3);
+    t1 << -U(0, 2), -U(1, 2), -U(2, 2);
+
+    std::cout << "t0:\n" << t0 << std::endl;
+
+    P0 = matrix34d::eye();
+
+    // 4 possible solutions
+    matrix34d P10 = composeP(R0, t0);
+    matrix34d P11 = composeP(R0, t1);
+    matrix34d P12 = composeP(R1, t0);
+    matrix34d P13 = composeP(R1, t1);
+    matrix34d P1s[4] = {P10, P11, P12, P13};
+
+    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
+    int best_count = 0;
+    int best_idx = -1;
+    for (int i = 0; i < 4; ++i) {
+        int count = 0;
+        for (int j = 0; j < (int) m0.size(); ++j) {
+            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
+                ++count;
+            }
+        }
+        std::cout << "decomposeEMatrix: count: " << count << std::endl;
+        if (count > best_count) {
+            best_count = count;
+            best_idx = i;
+        }
+    }
+
+    if (best_count == 0) {
+        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
+    }
+
+    P1 = P1s[best_idx];
+
+    std::cout << "best idx: " << best_idx << std::endl;
+    std::cout << "P0: \n" << P0 << std::endl;
+    std::cout << "P1: \n" << P1 << std::endl;
 }
 
 void phg::decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Matx34d &P)

--- a/src/phg/sfm/fmatrix.cpp
+++ b/src/phg/sfm/fmatrix.cpp
@@ -25,49 +25,77 @@ namespace {
     // (см. Hartley & Zisserman p.279)
     cv::Matx33d estimateFMatrixDLT(const cv::Vec2d *m0, const cv::Vec2d *m1, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        int a_rows = TODO;
-//        int a_cols = TODO;
-//
-//        Eigen::MatrixXd A(a_rows, a_cols);
-//
-//        for (int i_pair = 0; i_pair < count; ++i_pair) {
-//
-//            double x0 = m0[i_pair][0];
-//            double y0 = m0[i_pair][1];
-//
-//            double x1 = m1[i_pair][0];
-//            double y1 = m1[i_pair][1];
-//
-////            std::cout << "(" << x0 << ", " << y0 << "), (" << x1 << ", " << y1 << ")" << std::endl;
-//
-//            TODO
-//        }
-//
-//        Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//        Eigen::VectorXd null_space = TODO
-//
-//        Eigen::MatrixXd F(3, 3);
-//        F.row(0) << null_space[0], null_space[1], null_space[2];
-//        F.row(1) << null_space[3], null_space[4], null_space[5];
-//        F.row(2) << null_space[6], null_space[7], null_space[8];
-//
-////             Поправить F так, чтобы соблюдалось свойство фундаментальной матрицы (последнее сингулярное значение = 0)
-//        Eigen::JacobiSVD<Eigen::MatrixXd> svdf(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//          TODO
-//
-//        cv::Matx33d Fcv;
-//        copy(F, Fcv);
-//
-//        return Fcv;
+        int a_rows = count;
+        int a_cols = 9;
+
+        Eigen::MatrixXd A(a_rows, a_cols);
+
+        for (int i_pair = 0; i_pair < count; ++i_pair) {
+
+            double x0 = m0[i_pair][0];
+            double y0 = m0[i_pair][1];
+
+            double x1 = m1[i_pair][0];
+            double y1 = m1[i_pair][1];
+
+//            std::cout << "(" << x0 << ", " << y0 << "), (" << x1 << ", " << y1 << ")" << std::endl;
+
+            A.row(i_pair) <<
+                  x0*x1,
+                  y0*x1,
+                  x1,
+                  x0*y1,
+                  y0*y1,
+                  y1,
+                  x0,
+                  y0,
+                  1;
+        }
+
+        Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        Eigen::VectorXd null_space = svda.matrixV().col(8);
+
+        Eigen::MatrixXd F(3, 3);
+        F.row(0) << null_space[0], null_space[1], null_space[2];
+        F.row(1) << null_space[3], null_space[4], null_space[5];
+        F.row(2) << null_space[6], null_space[7], null_space[8];
+
+//             Поправить F так, чтобы соблюдалось свойство фундаментальной матрицы (последнее сингулярное значение = 0)
+        Eigen::JacobiSVD<Eigen::MatrixXd> svdf(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        Eigen::VectorXd singular_values = svdf.singularValues();
+        singular_values(2) = 0;
+
+        F = svdf.matrixU() * singular_values.asDiagonal() * svdf.matrixV().transpose();
+
+        cv::Matx33d Fcv;
+        copy(F, Fcv);
+
+        return Fcv;
     }
 
     // Нужно создать матрицу преобразования, которая сдвинет переданное множество точек так, что центр масс перейдет в ноль, а Root Mean Square расстояние до него станет sqrt(2)
     // (см. Hartley & Zisserman p.107 Why is normalization essential?)
     cv::Matx33d getNormalizeTransform(const std::vector<cv::Vec2d> &m)
     {
-        throw std::runtime_error("not implemented yet");
+        cv::Matx33d transform = cv::Matx33d::zeros();
+        transform(2, 2) = 1;
+        for (int i = 0; i < 2; i++) {
+            double sum = 0;
+            for (int j = 0; j < m.size(); j++) {
+                sum += m[j][i];
+            }
+            double mean = sum / (double)m.size();
+
+            double var = 0;
+            for (int j = 0; j < m.size(); j++) {
+                var += (m[j][i] - mean) * (m[j][i] - mean);
+            }
+            double sigma = std::sqrt(var / (double)m.size());
+            double coef = std::sqrt(2) / sigma;
+            transform(i, i) = coef;
+            transform(2, i) = - coef * mean;
+        }
+        return transform;
     }
 
     cv::Vec2d transformPoint(const cv::Vec2d &pt, const cv::Matx33d &T)
@@ -104,61 +132,60 @@ namespace {
             getNormalizeTransform(m0_t);
             getNormalizeTransform(m1_t);
         }
-        throw std::runtime_error("not implemented yet");
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//
-//        int best_support = 0;
-//        cv::Matx33d best_F;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_matches, n_samples, &seed);
-//
-//            cv::Vec2d ms0[n_samples];
-//            cv::Vec2d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = m0_t[sample[i]];
-//                ms1[i] = m1_t[sample[i]];
-//            }
-//
-//            cv::Matx33d F = estimateFMatrixDLT(ms0, ms1, n_samples);
-//
-//            // denormalize
-//            F = TODO
-//
-//            int support = 0;
-//            for (int i = 0; i < n_matches; ++i) {
-//                if (phg::epipolarTest(m0[i], m1[i], todo, threshold_px) && phg::epipolarTest(m1[i], m0[i], todo, threshold_px))
-//                {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_F = F;
-//
-//                std::cout << "estimateFMatrixRANSAC : support: " << best_support << "/" << n_matches << std::endl;
-//                infoF(F);
-//
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateFMatrixRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateFMatrixRANSAC : failed to estimate fundamental matrix");
-//        }
-//
-//        return best_F;
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_trials = 100000;
+
+        const int n_samples = 8;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx33d best_F;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_matches, n_samples, &seed);
+
+            cv::Vec2d ms0[n_samples];
+            cv::Vec2d ms1[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                ms0[i] = m0_t[sample[i]];
+                ms1[i] = m1_t[sample[i]];
+            }
+
+            cv::Matx33d F = estimateFMatrixDLT(ms0, ms1, n_samples);
+
+            // denormalize
+            F = TN1.t() * F * TN0;
+
+            int support = 0;
+            for (int i = 0; i < n_matches; ++i) {
+                if (phg::epipolarTest(m0[i], m1[i], F, threshold_px) && phg::epipolarTest(m1[i], m0[i], F, threshold_px))
+                {
+                    ++support;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_F = F;
+
+                std::cout << "estimateFMatrixRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+                infoF(F);
+
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateFMatrixRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateFMatrixRANSAC : failed to estimate fundamental matrix");
+        }
+
+        return best_F;
     }
 
 }

--- a/src/phg/sfm/homography.cpp
+++ b/src/phg/sfm/homography.cpp
@@ -84,8 +84,12 @@ namespace {
             double w1 = ws1[i];
 
             // 8 elements of matrix + free term as needed by gauss routine
-//            A.push_back({TODO});
-//            A.push_back({TODO});
+            A.push_back({
+                0.0, 0.0, 0.0, -w1*x0, -w1*y0, -w1*w0, y1*x0, y1*y0, -y1*w0
+            });
+            A.push_back({
+                w1*x0, w1*y0, w1*w0, 0.0, 0.0, 0.0, -x1*x0, -x1*y0, x1*w0
+            });
         }
 
         int res = gauss(A, H);
@@ -168,57 +172,57 @@ namespace {
         // * (простое описание для понимания)
         // * [3] http://ikrisoft.blogspot.com/2015/01/ransac-with-contrario-approach.html
 
-//        const int n_matches = points_lhs.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        const int n_trials = TODO;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//        const double reprojection_error_threshold_px = 2;
-//
-//        int best_support = 0;
-//        cv::Mat best_H;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            randomSample(sample, n_matches, n_samples, &seed);
-//
-//            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
-//                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
-//
-//            int support = 0;
-//            for (int i_point = 0; i_point < n_matches; ++i_point) {
-//                try {
-//                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
-//                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
-//                        ++support;
-//                    }
-//                } catch (const std::exception &e)
-//                {
-//                    std::cerr << e.what() << std::endl;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_H = H;
-//
-//                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
-//
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
-//        }
-//
-//        return best_H;
+        const int n_matches = points_lhs.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        const int n_trials = 60;
+
+        const int n_samples = 4;
+        uint64_t seed = 1;
+        const double reprojection_error_threshold_px = 2;
+
+        int best_support = 0;
+        cv::Mat best_H;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            randomSample(sample, n_matches, n_samples, &seed);
+
+            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
+                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
+
+            int support = 0;
+            for (int i_point = 0; i_point < n_matches; ++i_point) {
+                try {
+                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
+                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
+                        ++support;
+                    }
+                } catch (const std::exception &e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_H = H;
+
+                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
+        }
+
+        return best_H;
     }
 
 }
@@ -238,7 +242,10 @@ cv::Mat phg::findHomographyCV(const std::vector<cv::Point2f> &points_lhs, const 
 // таким преобразованием внутри занимается функции cv::perspectiveTransform и cv::warpPerspective
 cv::Point2d phg::transformPoint(const cv::Point2d &pt, const cv::Mat &T)
 {
-    throw std::runtime_error("not implemented yet");
+    double v[3][1] = {{pt.x}, {pt.y}, {1.f}};
+    cv::Mat m = T * cv::Mat(3, 1, CV_64F, v);
+    double z = m.at<double>(2, 0);
+    return {m.at<double>(0, 0) / z, m.at<double>(1, 0) / z};
 }
 
 cv::Point2d phg::transformPointCV(const cv::Point2d &pt, const cv::Mat &T) {

--- a/src/phg/sfm/panorama_stitcher.cpp
+++ b/src/phg/sfm/panorama_stitcher.cpp
@@ -4,6 +4,10 @@
 #include <libutils/bbox2.h>
 #include <iostream>
 
+cv::Point2d applyH(cv::Point2d pt, cv::Mat &h) {
+    return phg::transformPoint(pt, h);
+}
+
 /*
  * imgs - список картинок
  * parent - список индексов, каждый индекс указывает, к какой картинке должна быть приклеена текущая картинка
@@ -23,7 +27,32 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
     {
         // здесь надо посчитать вектор Hs
         // при этом можно обойтись n_images - 1 вызовами функтора homography_builder
-        throw std::runtime_error("not implemented yet");
+        std::vector<bool> visited(n_images, false);
+        std::vector<int> queue;
+        for (int i = 0; i < n_images; i++) {
+            queue.push_back(i);
+        }
+        while (!queue.empty()) {
+            int current = queue.back();
+
+            if (visited[current]) {
+                queue.pop_back();
+                continue;
+            }
+
+            int parent_ = parent[current];
+            if (parent_ < 0) {
+                Hs[current] = cv::Mat::eye(3, 3, CV_64F);
+                visited[current] = true;
+                queue.pop_back();
+            } else if (visited[parent_]) {
+                Hs[current] = Hs[parent_] * homography_builder(imgs[current], imgs[parent_]);
+                visited[current] = true;
+                queue.pop_back();
+            } else {
+                queue.push_back(parent_);
+            }
+        }
     }
 
     bbox2<double, cv::Point2d> bbox;
@@ -44,21 +73,21 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
     cv::Mat result = cv::Mat::zeros(result_height, result_width, CV_8UC3);
 
     // из-за растяжения пикселей при использовании прямой матрицы гомографии после отображения между пикселями остается пустое пространство
-    // лучше использовать обратную и для каждого пикселя на итоговвой картинке проверять, с какой картинки он может получить цвет
+    // лучше использовать обратную и для каждого пикселя на итоговой картинке проверять, с какой картинки он может получить цвет
     // тогда в некоторых пикселях цвет будет дублироваться, но изображение будет непрерывным
-//        for (int i = 0; i < n_images; ++i) {
-//            for (int y = 0; y < imgs[i].rows; ++y) {
-//                for (int x = 0; x < imgs[i].cols; ++x) {
-//                    cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
-//
-//                    cv::Point2d pt_dst = applyH(cv::Point2d(x, y), Hs[i]) - bbox.min();
-//                    int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
-//                    int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
-//
-//                    result.at<cv::Vec3b>(y_dst, x_dst) = color;
-//                }
-//            }
-//        }
+    for (int i = 0; i < n_images; ++i) {
+        for (int y = 0; y < imgs[i].rows; ++y) {
+            for (int x = 0; x < imgs[i].cols; ++x) {
+                cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
+
+                cv::Point2d pt_dst = applyH(cv::Point2d(x, y), Hs[i]) - bbox.min();
+                int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
+                int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
+
+                result.at<cv::Vec3b>(y_dst, x_dst) = color;
+            }
+        }
+    }
 
     std::vector<cv::Mat> Hs_inv;
     std::transform(Hs.begin(), Hs.end(), std::back_inserter(Hs_inv), [&](const cv::Mat &H){ return H.inv(); });

--- a/src/phg/sfm/resection.cpp
+++ b/src/phg/sfm/resection.cpp
@@ -49,95 +49,124 @@ namespace {
     // (см. Hartley & Zisserman p.178)
     cv::Matx34d estimateCameraMatrixDLT(const cv::Vec3d *Xs, const cv::Vec3d *xs, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        using mat = Eigen::MatrixXd;
-//        using vec = Eigen::VectorXd;
-//
-//        mat A(TODO);
-//
-//        for (int i = 0; i < count; ++i) {
-//
-//            double x = xs[i][0];
-//            double y = xs[i][1];
-//            double w = xs[i][2];
-//
-//            double X = Xs[i][0];
-//            double Y = Xs[i][1];
-//            double Z = Xs[i][2];
-//            double W = 1.0;
-//
-//            TODO
-//        }
-//
-//        matrix34d result;
-//          TODO
-//
-//        return canonicalizeP(result);
+        using mat = Eigen::MatrixXd;
+        using vec = Eigen::VectorXd;
+
+        mat A(2*count, 12);
+
+        for (int i = 0; i < count; ++i) {
+
+            double x = xs[i][0];
+            double y = xs[i][1];
+            double w = xs[i][2];
+
+            double X = Xs[i][0];
+            double Y = Xs[i][1];
+            double Z = Xs[i][2];
+            double W = 1.0;
+
+            A.row(2*i) <<
+                -w*X,
+                -w*Y,
+                -w*Z,
+                -w*W,
+                0,
+                0,
+                0,
+                0,
+                x*X,
+                x*Y,
+                x*Z,
+                x*W;
+            A.row(2*i+1) <<
+                0,
+                0,
+                0,
+                0,
+                w*X,
+                w*Y,
+                w*Z,
+                w*W,
+                -y*X,
+                -y*Y,
+                -y*Z,
+                -y*W;
+        }
+
+        Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        matrix34d result;
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 4; j++) {
+                result(i, j) = svda.matrixV()(4 * i + j, 11);
+            }
+        }
+
+        return canonicalizeP(result);
     }
 
 
     // По трехмерным точкам и их проекциям на изображении определяем положение камеры
     cv::Matx34d estimateCameraMatrixRANSAC(const phg::Calibration &calib, const std::vector<cv::Vec3d> &X, const std::vector<cv::Vec2d> &x)
     {
-        throw std::runtime_error("not implemented yet");
-//        if (X.size() != x.size()) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
-//        }
-//
-//        const int n_points = X.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
-//
-//        const double threshold_px = 3;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//
-//        int best_support = 0;
-//        cv::Matx34d best_P;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_points, n_samples, &seed);
-//
-//            cv::Vec3d ms0[n_samples];
-//            cv::Vec3d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = TODO;
-//                ms1[i] = TODO;
-//            }
-//
-//            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
-//
-//            int support = 0;
-//            for (int i = 0; i < n_points; ++i) {
-//                cv::Vec2d px = TODO спроецировать 3Д точку в пиксель с использованием P и calib;
-//                if (cv::norm(px - x[i]) < threshold_px) {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_P = P;
-//
-//                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
-//
-//                if (best_support == n_points) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
-//        }
-//
-//        return best_P;
+        if (X.size() != x.size()) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
+        }
+
+        const int n_points = X.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_trials = 100000;
+
+        const double threshold_px = 3;
+
+        const int n_samples = 6;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx34d best_P;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_points, n_samples, &seed);
+
+            cv::Vec3d ms0[n_samples];
+            cv::Vec3d ms1[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                ms0[i] = X[sample[i]];
+                ms1[i] = calib.unproject(x[sample[i]]);
+            }
+
+            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
+
+            int support = 0;
+            for (int i = 0; i < n_points; ++i) {
+                vector3d px_ = calib.project(P * vector4d(X[i][0], X[i][1], X[i][2], 1.0));
+                cv::Vec2d px(px_[0] / px_[2], px_[1] / px_[2]); // спроецировать 3Д точку в пиксель с использованием P и calib;
+                if (cv::norm(px - x[i]) < threshold_px) {
+                    ++support;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_P = P;
+
+                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
+
+                if (best_support == n_points) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
+        }
+
+        return best_P;
     }
 
 

--- a/src/phg/sfm/sfm_utils.cpp
+++ b/src/phg/sfm/sfm_utils.cpp
@@ -41,5 +41,8 @@ void phg::randomSample(std::vector<int> &dst, int max_id, int sample_size, uint6
 // проверяет, что расстояние от точки до линии меньше порога
 bool phg::epipolarTest(const cv::Vec2d &pt0, const cv::Vec2d &pt1, const cv::Matx33d &F, double t)
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Vec3d point(pt0[0], pt0[1], 1.0);
+    cv::Vec3d eqn = F * point;
+    auto dist = std::abs(eqn[0] * pt1[0] + eqn[1] * pt1[1] + eqn[2]) / std::sqrt(eqn[0]*eqn[0] + eqn[1]*eqn[1]);
+    return dist < t;
 }

--- a/src/phg/sfm/triangulation.cpp
+++ b/src/phg/sfm/triangulation.cpp
@@ -12,5 +12,30 @@ cv::Vec4d phg::triangulatePoint(const cv::Matx34d *Ps, const cv::Vec3d *ms, int 
 {
     // составление однородной системы + SVD
     // без подвохов
-    throw std::runtime_error("not implemented yet");
+    std::pair<int, int> size = {2*count, 3};
+    Eigen::MatrixXd A(size.first, size.second);
+    Eigen::VectorXd b(size.first);
+
+    for (int i_pair = 0; i_pair < count; ++i_pair) {
+        double x = ms[i_pair][0];
+        double y = ms[i_pair][1];
+        double z = ms[i_pair][2];
+
+        for (int i = 0; i < 3; i++) {
+            A(2*i_pair, i) = x * Ps[i_pair](2, i) - z * Ps[i_pair](0, i);
+            A(2*i_pair+1, i) = y * Ps[i_pair](2, i) - z * Ps[i_pair](1, i);
+        }
+
+        b(2*i_pair) = -x * Ps[i_pair](2, 3) + z * Ps[i_pair](0, 3);
+        b(2*i_pair+1) = -y * Ps[i_pair](2, 3) + z * Ps[i_pair](1, 3);
+    }
+
+    Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::MatrixXd s_inv = Eigen::MatrixXd::Zero(size.second, size.first);
+    for (int i = 0; i < 3; i++) {
+        s_inv(i, i) = 1 / svda.singularValues()[i];
+    }
+    Eigen::VectorXd solution = svda.matrixV() * s_inv * svda.matrixU().transpose() * b;
+    cv::Vec4d solution_cv = {solution[0], solution[1], solution[2], 1};
+    return solution_cv;
 }

--- a/tests/test_matching.cpp
+++ b/tests/test_matching.cpp
@@ -20,7 +20,7 @@
 
 // TODO enable both toggles for testing custom detector & matcher
 #define ENABLE_MY_DESCRIPTOR 0
-#define ENABLE_MY_MATCHING 0
+#define ENABLE_MY_MATCHING 1
 #define ENABLE_GPU_BRUTEFORCE_MATCHER 0
 
 #if ENABLE_MY_MATCHING
@@ -147,6 +147,7 @@ namespace {
         keypoints_rmse = 0;
         for (int i = 0; i < (int) good_matches.size(); ++i) {
 #if ENABLE_MY_MATCHING
+            std::cout << "transform" << std::endl;
             cv::Point2f pt = phg::transformPoint(points1[i], H);
 #else
             cv::Point2f pt = phg::transformPointCV(points1[i], H);
@@ -163,6 +164,7 @@ namespace {
             for (int x = 0; x < img1.cols; ++x) {
                 cv::Vec3b col1 = img1.at<cv::Vec3b>(y, x);
 #if ENABLE_MY_MATCHING
+                std::cout << "transform point " << y  << " : " << x << std::endl;
                 cv::Point2f pt = phg::transformPoint(cv::Point2f(x, y), H);
 #else
                 cv::Point2f pt = phg::transformPointCV(cv::Point2f(x, y), H);
@@ -193,6 +195,7 @@ namespace {
     void testStitching(const cv::Mat &img1, const cv::Mat &img2, const std::vector<cv::KeyPoint> &keypoints1, const std::vector<cv::KeyPoint> &keypoints2,
                        const cv::Mat &descriptors1, const cv::Mat &descriptors2)
     {
+        std::cout << "testStitching" << std::endl;
         double rmse_kpts, rmse_color;
         evaluateStitching(img1, img2, rmse_kpts, rmse_color, keypoints1, keypoints2, descriptors1, descriptors2);
 

--- a/tests/test_sfm.cpp
+++ b/tests/test_sfm.cpp
@@ -18,7 +18,7 @@
 #include "utils/test_utils.h"
 
 
-#define ENABLE_MY_SFM 0
+#define ENABLE_MY_SFM 1
 
 namespace {
 

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -116,12 +116,11 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                 detector->compute(img1, kps1, desc1);
             } else if (method == 2) {
                 // TODO remove 'return' and uncomment
-                return;
-//                method_name = "SIFT_MY";
-//                log_prefix = "[SIFT_MY] ";
-//                phg::SIFT mySIFT;
-//                mySIFT.detectAndCompute(img0, kps0, desc0);
-//                mySIFT.detectAndCompute(img1, kps1, desc1);
+                method_name = "SIFT_MY";
+                log_prefix = "[SIFT_MY] ";
+                phg::SIFT mySIFT;
+                mySIFT.detectAndCompute(img0, kps0, desc0);
+                mySIFT.detectAndCompute(img1, kps1, desc1);
             } else {
                 rassert(false, 13532513412); // это не проверка как часть тестирования, это проверка что число итераций в цикле и if-else ветки все еще согласованы и не разошлись
             }


### PR DESCRIPTION
1) Мы можем получить облако точек и взаимную ориентацию по двум камерам. Почему для выравнивания трёх камер мы использовали резекцию, а не посчитали E матрицу для второй пары камер и не разложили ее?

* больше погрешность и время из-за увеличения операций
* теряется связь со второй камерой, из-за этого появляются различные варианты их расположения, но можно попытаться повторить с парой 2-3, но это еще больше усложнит алгоритм

2) Как реализовать выравнивание если мы все же хотим использовать Е матрицу?

* найти 3d точки для двух первых камер
* посчитать E для третьей камеры, получить положение относительно первой
* триангулировать новые точки и точки, которые видят все три камеры

<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_sift
$ ./build/test_matching
Running main() from /home/runner/work/PhotogrammetryTasks2023/PhotogrammetryTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 22 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 22 tests from SIFT
[ RUN      ] SIFT.MovedTheSameImage
[ORB_OCV] Points detected: 500 -> 500 (in 0.021269 sec)
...
[       OK ] SIFT.HerzJesu19RotateM40 (7730 ms)
[----------] 22 tests from SIFT (12918 ms total)
[----------] Global test environment tear-down
[==========] 22 tests from 1 test suite ran. (12918 ms total)
[  PASSED  ] 22 tests.
...
</pre>

</p></details>