### PR TITLE
Task01 Денис Филиппов ВШЭ

### DIFF
--- a/src/phg/sift/sift.cpp
+++ b/src/phg/sift/sift.cpp
@@ -35,6 +35,7 @@
 #define DESCRIPTOR_SAMPLES_N       4 // 4x4 замера для каждой гистограммы дескриптора (всего гистограмм 4х4) итого 16х16 замеров
 #define DESCRIPTOR_SAMPLE_WINDOW_R 1.0 // минимальный радиус окна в рамках которого строится гистограмма из 8 корзин-направлений (т.е. для каждого из 16 элементов дескриптора), R=1 => 1x1 окно
 
+#define SMOOTH 0.5
 
 void phg::SIFT::detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc) {
     // используйте дебаг в файлы как можно больше, это очень удобно и потраченное время окупается крайне сильно,
@@ -79,13 +80,13 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
             int layer = 0;
             size_t prevOctave = octave - 1;
             // берем картинку с предыдущей октавы и уменьшаем ее в два раза без какого бы то ни было дополнительного размытия (сигмы должны совпадать)
-            // cv::Mat img = gaussianPyramid[ TODO ].clone();
+            cv::Mat img = gaussianPyramid[prevOctave * OCTAVE_GAUSSIAN_IMAGES].clone();
             // тут есть очень важный момент, мы должны указать fx=0.5, fy=0.5 иначе при нечетном размере картинка будет не идеально 2 пикселя в один схлопываться - а слегка смещаться
-            // cv::resize(img, img, cv::Size( TODO , TODO ), 0.5, 0.5, cv::INTER_NEAREST);
-            // gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
+            cv::resize(img, img, cv::Size(0, 0), 0.5, 0.5, cv::INTER_NEAREST);
+            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
         }
 
-//        #pragma omp parallel for // TODO: если выполните TODO про "размытие из изначального слоя октавы" ниже - раскоментируйте это распараллеливание, ведь теперь слои считаются независимо (из самого первого), проверьте что результат на картинках не изменился
+        #pragma omp parallel for // TODO: если выполните TODO про "размытие из изначального слоя октавы" ниже - раскоментируйте это распараллеливание, ведь теперь слои считаются независимо (из самого первого), проверьте что результат на картинках не изменился
         for (ptrdiff_t layer = 1; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
             size_t prevLayer = layer - 1;
 
@@ -100,9 +101,14 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
             // TODO: переделайте это добавочное размытие с варианта "размываем предыдущий слой" на вариант "размываем самый первый слой октавы до степени размытия сигмы нашего текущего слоя"
             // проверьте - картинки отладочного вывода выглядят один-в-один до/после? (посмотрите на них туда-сюда быстро мигая)
 
-            cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + prevLayer].clone();
+            cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES].clone();
             cv::Size automaticKernelSize = cv::Size(0, 0);
 
+            // sigmaFirst = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, 0) = INITIAL_IMG_SIGMA * pow(2.0, octave)
+            // sigma = sqrt(sigmaCur * sigmaCur - sigmaFirst * sigmaFirst)
+            //       = sqrt(INITIAL_IMG_SIGMA * INITIAL_IMG_SIGMA * pow (2.0, 2 * octave) * ((pow(k, 2 * layer) - 1))
+            //       = INITIAL_IMG_SIGMA * pow(2.0, octave) * sqrt(pow(k, 2 * layer) - 1)
+            sigma = INITIAL_IMG_SIGMA * pow(2.0, octave) * sqrt(pow(k, 2 * layer) - 1);
             cv::GaussianBlur(imgLayer, imgLayer, automaticKernelSize, sigma, sigma);
 
             gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = imgLayer;
@@ -155,7 +161,7 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
 }
 
 namespace {
-    float parabolaFitting(float x0, float x1, float x2) {
+    std::pair<float, float> parabolaFitting(float x0, float x1, float x2) {
         rassert((x1 >= x0 && x1 >= x2) || (x1 <= x0 && x1 <= x2), 12541241241241);
 
         // a*0^2+b*0+c=x0
@@ -171,8 +177,8 @@ namespace {
         float a = (x2-2.0f*x1+x0) / 2.0f;
         float b = x1 - x0 - a;
         // extremum is at -b/(2*a), but our system coordinate start (i) is at 1, so minus 1
-        float shift = - b / (2.0f * a) - 1.0f;
-        return shift;
+        float extremum = - b / (2.0f * a);
+        return {extremum - 1.0f, a * extremum * extremum + b * extremum + x0};
     }
 }
 
@@ -203,11 +209,16 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                         bool is_min = true;
                         float center = DoGs[1].at<float>(j, i);
                         for (int dz = -1; dz <= 1 && (is_min || is_max); ++dz) {
-                        for (int dy = -1; dy <= 1 && (is_min || is_max); ++dy) {
-                        for (int dx = -1; dx <= 1 && (is_min || is_max); ++dx) {
-                            // TODO проверить является ли наш центр все еще экстремум по сравнению с соседом DoGs[1+dz].at<float>(j+dy, i+dx) ? (не забудьте учесть что один из соседов - это мы сами)
-                        }
-                        }
+                            for (int dy = -1; dy <= 1 && (is_min || is_max); ++dy) {
+                                for (int dx = -1; dx <= 1 && (is_min || is_max); ++dx) {
+                                    // TODO проверить является ли наш центр все еще экстремум по сравнению с соседом DoGs[1+dz].at<float>(j+dy, i+dx) ? (не забудьте учесть что один из соседов - это мы сами)
+                                    if (dz != 0 || dy != 0 || dx != 0) {
+                                        float cur = DoGs[1 + dz].at<float>(j + dy, i + dx);
+                                        is_min = is_min && center <= cur;
+                                        is_max = is_max && center >= cur;
+                                    }
+                                }
+                            }
                         }
                         bool is_extremum = (is_min || is_max);
 
@@ -223,6 +234,20 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
 #if SUBPIXEL_FITTING_ENABLE // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
                         {
                             // TODO
+                            std::pair<float, float>
+                                    shiftWithDValueX = parabolaFitting(
+                                    DoGs[1].at<float>(j, i - 1),
+                                    center,
+                                    DoGs[1].at<float>(j, i + 1)
+                            ),
+                                    shiftWithDValueY = parabolaFitting(
+                                    DoGs[1].at<float>(j - 1, i),
+                                    center,
+                                    DoGs[1].at<float>(j + 1, i)
+                            );
+                            dx = shiftWithDValueX.first;
+                            dy = shiftWithDValueY.first;
+                            dvalue = (shiftWithDValueX.second + shiftWithDValueY.second) / 2.0f;
                         }
 #endif
                         // TODO сделать фильтрацию слабых точек по слабому контрасту
@@ -252,7 +277,8 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                             float nextValue = votes[(bin + 1) % ORIENTATION_NHISTS];
                             if (value > prevValue && value > nextValue && votes[bin] > biggestVote * ORIENTATION_VOTES_PEAK_RATIO) {
                                 // TODO добавьте уточнение угла наклона - может помочь определенная выше функция parabolaFitting(float x0, float x1, float x2)
-                                kp.angle = (bin + 0.5) * (360.0 / ORIENTATION_NHISTS);
+                                float shift = parabolaFitting(prevValue, value, nextValue).first;
+                                kp.angle = (shift + 0.5) * (360.0 / ORIENTATION_NHISTS);
                                 rassert(kp.angle >= 0.0 && kp.angle <= 360.0, 123512412412);
                                 
                                 std::vector<float> descriptor;
@@ -301,21 +327,25 @@ bool phg::SIFT::buildLocalOrientationHists(const cv::Mat &img, size_t i, size_t 
     for (size_t y = j - radius + 1; y < j + radius; ++y) {
         for (size_t x = i - radius + 1; x < i + radius; ++x) {
             // m(x, y)=(L(x + 1, y) − L(x − 1, y))^2 + (L(x, y + 1) − L(x, y − 1))^2
-            // double magnitude = TODO
+            double dx = img.at<float>(y, x + 1) - img.at<float>(y, x - 1);
+            double dy = img.at<float>(y + 1, x) - img.at<float>(y - 1, x);
+            double magnitude = dx * dx + dy * dy;
 
             // orientation == theta
             // atan( (L(x, y + 1) − L(x, y − 1)) / (L(x + 1, y) − L(x − 1, y)) )
-            // double orientation = TODO // подсказка - используйте atan2(dy, dx)
-//            orientation = orientation * 180.0 / M_PI;
-//            orientation = (orientation + 90.0);
-//            if (orientation <  0.0)   orientation += 360.0;
-//            if (orientation >= 360.0) orientation -= 360.0;
-//            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
-//            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
-//            size_t bin = TODO
-//            rassert(bin < ORIENTATION_NHISTS, 361236315613);
-//            sum[bin] += magnitude;
+            double orientation = atan2(dy, dx); // подсказка - используйте atan2(dy, dx)
+            orientation = orientation * 180.0 / M_PI;
+            orientation = (orientation + 90.0);
+            if (orientation <  0.0)   orientation += 360.0;
+            if (orientation >= 360.0) orientation -= 360.0;
+            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
+            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
+            size_t bin = orientation * ORIENTATION_NHISTS / 360.0;
+            rassert(bin < ORIENTATION_NHISTS, 361236315613);
+            sum[bin] += magnitude;
             // TODO может быть сгладить получившиеся гистограммы улучшит результат? 
+            sum[(bin + 1) % ORIENTATION_NHISTS] += magnitude * SMOOTH;
+            sum[(bin + ORIENTATION_NHISTS - 1) % ORIENTATION_NHISTS] += magnitude * SMOOTH;
         }
     }
 
@@ -343,39 +373,54 @@ bool phg::SIFT::buildDescriptor(const cv::Mat &img, float px, float py, double d
                 for (int smpi = 0; smpi < DESCRIPTOR_SAMPLES_N; ++smpi) { // перебираем столбик очередного замера для текущей гистограммы
                     for (int smpy = 0; smpy < smpW; ++smpy) { // перебираем ряд пикселей текущего замера
                         for (int smpx = 0; smpx < smpW; ++smpx) { // перебираем столбик пикселей текущего замера
-//                            cv::Point2f shift(((-DESCRIPTOR_SIZE/2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW, TODO);
-//                            std::vector<cv::Point2f> shiftInVector(1, shift);
-//                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation); // преобразуем относительный сдвиг с учетом ориентации ключевой точки
-//                            shift = shiftInVector[0];
+                            cv::Point2f shift(
+                                    ((-DESCRIPTOR_SIZE/2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW,
+                                    ((-DESCRIPTOR_SIZE/2.0 + hstj) * DESCRIPTOR_SAMPLES_N + smpj) * smpW
+                            );
+                            std::vector<cv::Point2f> shiftInVector(1, shift);
+                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation); // преобразуем относительный сдвиг с учетом ориентации ключевой точки
+                            shift = shiftInVector[0];
 
-//                            int x = (int) (px + shift.x);
-//                            int y = TODO;
+                            int x = (int) (px + shift.x);
+                            int y = (int) (py + shift.y);
 
-//                            if (y - 1 < 0 || y + 1 > img.rows || x - 1 < 0 || x + 1 > img.cols)
-//                                return false;
+                            if (y - 1 < 0 || y + 1 >= img.rows || x - 1 < 0 || x + 1 >= img.cols)
+                                return false;
 
-//                            double magnitude = TODO
+                            double dx = img.at<float>(y, x + 1) - img.at<float>(y, x - 1);
+                            double dy = img.at<float>(y + 1, x) - img.at<float>(y - 1, x);
+                            double magnitude = dx * dx + dy * dy;
 
-//                            double orientation = atan2(TODO);
-//                            orientation = orientation * 180.0 / M_PI;
-//                            orientation = (orientation + 90.0);
-//                            if (orientation <  0.0)   orientation += 360.0;
-//                            if (orientation >= 360.0) orientation -= 360.0;
+                            double orientation = atan2(dy, dx);
+                            orientation = orientation * 180.0 / M_PI;
+                            orientation = (orientation + 90.0 - angle);
+                            if (orientation <  0.0)   orientation += 360.0;
+                            if (orientation >= 360.0) orientation -= 360.0;
 
                               // TODO за счет чего этот вклад будет сравниваться с этим же вкладом даже если эта картинка будет повернута? что нужно сделать с ориентацией каждого градиента из окрестности этой ключевой точки?
 
-//                            rassert(orientation >= 0.0 && orientation < 360.0, 3515215125412);
+                            rassert(orientation >= 0.0 && orientation < 360.0, 3515215125412);
                             static_assert(360 % DESCRIPTOR_NBINS == 0, "Inappropriate bins number!");
-//                            size_t bin = TODO;
-//                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
-//                            sum[bin] += magnitude;
+                            size_t bin = orientation * DESCRIPTOR_NBINS / 360.0;
+                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
+                            sum[bin] += magnitude;
                             // TODO хорошая идея добавить трилинейную интерполяцию как предложено в статье, или хотя бы сэмулировать ее - сгладить получившиеся гистограммы
+                            sum[(bin + 1) % DESCRIPTOR_NBINS] += magnitude * SMOOTH;
+                            sum[(bin + DESCRIPTOR_NBINS - 1) % DESCRIPTOR_NBINS] += magnitude * SMOOTH;
                         }
                     }
                 }
             }
 
             // TODO нормализовать наш вектор дескриптор (подсказка: посчитать его длину и поделить каждую компоненту на эту длину)
+            float len2 = 0.0;
+            for (float s : sum) {
+                len2 += s * s;
+            }
+            float len = std::sqrt(len2);
+            for (float &s : sum) {
+                s /= len;
+            }
 
             float *votes = &(descriptor[(hstj * DESCRIPTOR_SIZE + hsti) * DESCRIPTOR_NBINS]); // нашли где будут лежать корзины нашей гистограммы
             for (int bin = 0; bin < DESCRIPTOR_NBINS; ++bin) {

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -119,12 +119,11 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                 detector->compute(img1, kps1, desc1);
             } else if (method == 2) {
                 // TODO remove 'return' and uncomment
-                return;
-//                method_name = "SIFT_MY";
-//                log_prefix = "[SIFT_MY] ";
-//                phg::SIFT mySIFT;
-//                mySIFT.detectAndCompute(img0, kps0, desc0);
-//                mySIFT.detectAndCompute(img1, kps1, desc1);
+                method_name = "SIFT_MY";
+                log_prefix = "[SIFT_MY] ";
+                phg::SIFT mySIFT;
+                mySIFT.detectAndCompute(img0, kps0, desc0);
+                mySIFT.detectAndCompute(img1, kps1, desc1);
             } else {
                 rassert(false, 13532513412); // это не проверка как часть тестирования, это проверка что число итераций в цикле и if-else ветки все еще согласованы и не разошлись
             }


### PR DESCRIPTION
1) Почему SIFT менее точно угадывает средний угол отклонения? изменяется ли ситуация если выкрутить параметр ORIENTATION_VOTES_PEAK_RATIO=0.999? почему?

SIFT угадывает средний угол отклонения менее точно, т.к. он зачастую выдаёт несколько направлений, среди которых только одно является верным, а остальные -- ошибочными. Если же
выкрутить ORIENTATION_VOTES_PEAK_RATIO до 0.999, то да, если алгоритм ошибается, то всё, другого, верного направления, он не выдаст, но с учетом того, что алгоритм работает более менее хорошо,
чаще он выдает верное направление.

2) Как надежно замерить во сколько раз распараллеливание через OpenMP ускоряет ваш вариант SIFT? Попробуйте сделать это на вашем компьютере, какое ускорение относительно однопоточной версии оказалось? Сколько у вашего процессора ядер и сколько потоков?

Отключаем все методы, кроме SIFT_MY и запускаем тесты. При включенном OpenMP получилось 240 секунд, при выключенном -- 540. Разница 2.25. И с точки зрения разницы, всё-таки у меня 4 ядра и 8 потоков у
процессора. И абсолютные показатели тоже не внушительные, хотя кроме браузера ничего открыто не было.

3) Правда ли можно строить каждый слой в Gaussian пирамиде из самого первого слоя этой октавы? Или нужно обязательно делать так как предложено в статье - дополняя размытие предыдущего слоя этой октавы? Совпадают ли пирамиды визуально?

Да, можно строить из первого слоя. Визуально пирамиды не отличаются.

4) Какие ожидания от картинок в Gaussian пирамиде можно придумать? Как проверить что работает корректно? С какой другой картинкой предыдущей октавы должна визуально совпадать конкретная картинка конкретной октавы? Как их визуально сравнить, ведь они разного размера?

Картинки с каждым слоем в октаве быть более размытыми. Конкретная картинка не будет в точности совпадать с конкретной картинкой другой октавы, т.к. у них разные размеры. Но если взять i-ую картинку
из j-ой октавы, уменьшить её размеры в 2 раза и взять (i-1)-ую картинку из (j+1)-ой октавы, то эти картинки должны быть похожи, т.к. уменьшение картинки в размерах похоже на размытие.


5) Почему в октаве Gaussian пирамиды s+3 картинки а не s+2 например?

В DoG пирамиде для каждого из s слоев должна быть картинка из предыдущего и последующего слоя, чтобы можно было опрелить экстремум. Для этого в DoG нужно ещё 2 картинки добавить. А чтобы их получить,
нужно в октаву добавить 3 картинки, т.к. в октаве картинок на одну больше, чем в DoG.

6) Какие ожидания от картинок в DoG пирамиде можно придумать?

В сумме получается исходная картинка без среднего цвета. В начале картинки должны быть темными с каким-то узкими яркими вкраплениями, которые очерчивают контуры каких-то объектов исходного изображения. Ближе к концу картинки более светлы, но при этом там не узникие точечные вкрапления, а целые пятна, также напоминающие какие-то объекты, но уже более крупные и не с четкими границами.

7) Почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?

Чем больше слоев, тем меньше размытие и тем меньше контрольных точек выделяется на каждом слое при неизменном пороге и при увелечинии числа слоев. Поэтому порог нужно уменьшать

8) Какая строка ответственна за определение сигмы (или что почти то же самое - радиуса) которая задает окрестность по которой определяется ориентация ключевой точки?

111 строка: `sigma = INITIAL_IMG_SIGMA * pow(2.0, octave) * sqrt(pow(k, 2 * layer) - 1);`


9) За какой строки вашего кода дескриптор инвариантен к повороту картинки?

396 строк: `orientation = (orientation + 90.0 - angle);`

<details><summary>Github Actions CI</summary><p>

<pre>
$ ./build/test_sift
TODO
</pre>

</p></details>