### PR TITLE
Task03 Денис Коротченко МКН

### DIFF
--- a/src/phg/matching/descriptor_matcher.cpp
+++ b/src/phg/matching/descriptor_matcher.cpp
@@ -8,7 +8,10 @@ void phg::DescriptorMatcher::filterMatchesRatioTest(const std::vector<std::vecto
 {
     filtered_matches.clear();
 
-    throw std::runtime_error("not implemented yet");
+    for (auto match: matches) {
+        if (match.size() == 1 || match[0].distance / match[1].distance < 0.6)
+            filtered_matches.push_back(match[0]);
+    }
 }
 
 
@@ -37,40 +40,58 @@ void phg::DescriptorMatcher::filterMatchesClusters(const std::vector<cv::DMatch>
     }
 //
 //    // размерность всего 2, так что точное KD-дерево
-//    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(TODO);
-//    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(TODO);
-//
-//    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
-//    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
+    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(1);
+    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(32);
+
+    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
+    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
 //
 //    // для каждой точки найти total neighbors ближайших соседей
-//    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
-//    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
-//
-//    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
-//    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
+    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
+    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
+
+    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
+    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
 //
 //    // оценить радиус поиска для каждой картинки
 //    // NB: radius2_query, radius2_train: квадраты радиуса!
-//    float radius2_query, radius2_train;
-//    {
-//        std::vector<double> max_dists2_query(n_matches);
-//        std::vector<double> max_dists2_train(n_matches);
-//        for (int i = 0; i < n_matches; ++i) {
-//            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
-//            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
-//        }
-//
-//        int median_pos = n_matches / 2;
-//        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
-//        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
-//
-//        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
-//        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
-//    }
-//
+    float radius2_query, radius2_train;
+    {
+        std::vector<double> max_dists2_query(n_matches);
+        std::vector<double> max_dists2_train(n_matches);
+        for (int i = 0; i < n_matches; ++i) {
+            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
+            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
+        }
+
+        int median_pos = n_matches / 2;
+        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
+        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
+
+        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
+        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
+    }
+
 //    метч остается, если левое и правое множества первых total_neighbors соседей в радиусах поиска(radius2_query, radius2_train) имеют как минимум consistent_matches общих элементов
-//    // TODO заполнить filtered_matches
+    filtered_matches.clear();
+    for (int i = 0; i < n_matches; ++i) {
+        std::set<int> query_ind_in_rad;
+        for (int j = 0; j < total_neighbours && distances2_query.at<float>(i, j) <= radius2_query; ++j) {
+            //printf("%f ", distances2_query.at<float>(i, j));
+            query_ind_in_rad.insert(indices_query.at<int>(i, j));
+        }
+        //printf("\n");
+
+        int count = 0;
+        for (int j = 0; j < total_neighbours && distances2_train.at<float>(i, j) <= radius2_train; ++j) {
+            if (query_ind_in_rad.count(indices_train.at<int>(i, j)) > 0) {
+                count++;
+            }
+        }
+        if (count >= consistent_matches) {
+            filtered_matches.push_back(matches[i]);
+        }
+    }
 }

--- a/src/phg/matching/flann_matcher.cpp
+++ b/src/phg/matching/flann_matcher.cpp
@@ -6,8 +6,11 @@
 phg::FlannMatcher::FlannMatcher()
 {
     // параметры для приближенного поиска
-//    index_params = flannKdTreeIndexParams(TODO);
-//    search_params = flannKsTreeSearchParams(TODO);
+    // я 100% не там искал, но вот здесь нашёл дефолтные параметры 4/32
+    // http://lumiguide.github.io/haskell-opencv/doc/src/OpenCV-Features2d.html
+    // и с ними как будто нормально работает
+    index_params = flannKdTreeIndexParams(4);
+    search_params = flannKsTreeSearchParams(32);
 }
 
 void phg::FlannMatcher::train(const cv::Mat &train_desc)
@@ -17,5 +20,15 @@ void phg::FlannMatcher::train(const cv::Mat &train_desc)
 
 void phg::FlannMatcher::knnMatch(const cv::Mat &query_desc, std::vector<std::vector<cv::DMatch>> &matches, int k) const
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Mat indices, dists;
+    flann_index->knnSearch(query_desc, indices, dists, k, *search_params);
+
+    int match_n = query_desc.rows;
+    matches.resize(match_n);
+    for (int i = 0; i < match_n; i++) {
+        matches[i].resize(k);
+        for (int j = 0; j < k; j++) {
+            matches[i][j] = cv::DMatch(i, indices.at<int>(i, j), dists.at<float>(i, j));
+        }
+    }
 }

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -18,9 +18,12 @@ namespace {
         copy(Ecv, E);
 
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-        throw std::runtime_error("not implemented yet");
-// TODO
+        //throw std::runtime_error("not implemented yet");
+        Eigen::Matrix<double, 3, 3> newD;
+        newD(0, 0) = svd.singularValues()[0];
+        newD(1, 1) = svd.singularValues()[0];
 
+        E = svd.matrixU() * newD * svd.matrixV().transpose();
         copy(E, Ecv);
     }
 
@@ -28,12 +31,12 @@ namespace {
 
 cv::Matx33d phg::fmatrix2ematrix(const cv::Matx33d &F, const phg::Calibration &calib0, const phg::Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    matrix3d E = TODO;
+//    throw std::runtime_error("not implemented yet");
+    matrix3d E = calib0.K().t() * F * calib1.K();
 //
-//    ensureSpectralProperty(E);
+    ensureSpectralProperty(E);
 //
-//    return E;
+    return E;
 }
 
 namespace {
@@ -61,21 +64,21 @@ namespace {
 
     bool depthTest(const vector2d &m0, const vector2d &m1, const phg::Calibration &calib0, const phg::Calibration &calib1, const matrix34d &P0, const matrix34d &P1)
     {
-        throw std::runtime_error("not implemented yet");
+//        throw std::runtime_error("not implemented yet");
 //        // скомпенсировать калибровки камер
-//        vector3d p0 = TODO;
-//        vector3d p1 = TODO;
+        vector3d p0 = calib0.unproject(m0);
+        vector3d p1 = calib1.unproject(m1);
 //
-//        vector3d ps[2] = {p0, p1};
-//        matrix34d Ps[2] = {P0, P1};
-//
-//        vector4d X = phg::triangulatePoint(Ps, ps, 2);
-//        if (X[3] != 0) {
-//            X /= X[3];
-//        }
-//
-//        // точка должна иметь положительную глубину для обеих камер
-//        return TODO && TODO;
+        vector3d ps[2] = {p0, p1};
+        matrix34d Ps[2] = {P0, P1};
+
+        vector4d X = phg::triangulatePoint(Ps, ps, 2);
+        if (X[3] != 0) {
+            X /= X[3];
+        }
+
+        // точка должна иметь положительную глубину для обеих камер
+        return calib0.project(P0 * X)[2] > 0 && calib1.project(P1 * X)[2] > 0;
     }
 }
 
@@ -88,80 +91,83 @@ namespace {
 // первичное разложение существенной матрицы (а из него, взаимное расположение камер) для последующего уточнения методом нелинейной оптимизации
 void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &Ecv, const std::vector<cv::Vec2d> &m0, const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    if (m0.size() != m1.size()) {
-//        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
-//    }
+//    throw std::runtime_error("not implemented yet");
+    if (m0.size() != m1.size()) {
+        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
+    }
+
+    using mat = Eigen::MatrixXd;
+    using vec = Eigen::VectorXd;
+
+    mat E;
+    copy(Ecv, E);
+
+    // (см. Hartley & Zisserman p.258)
+
+    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+    mat U = svd.matrixU();
+    vec s = svd.singularValues();
+    mat V = svd.matrixV();
+
+    // U, V must be rotation matrices, not just orthogonal
+    if (U.determinant() < 0) U = -U;
+    if (V.determinant() < 0) V = -V;
+
+    std::cout << "U:\n" << U << std::endl;
+    std::cout << "s:\n" << s << std::endl;
+    std::cout << "V:\n" << V << std::endl;
+
+    mat W(3, 3);
+    W(0, 1) = -1;
+    W(1, 0) = 1;
+    W(2, 2) = 1;
+    mat R0 = U * W * V.transpose();
+    mat R1 = U * W.transpose() * V.transpose();
 //
-//    using mat = Eigen::MatrixXd;
-//    using vec = Eigen::VectorXd;
+    std::cout << "R0:\n" << R0 << std::endl;
+    std::cout << "R1:\n" << R1 << std::endl;
+
+    vec t0 = U.col(2);
+    vec t1 = U.col(2) * (-1);
+
+    std::cout << "t0:\n" << t0 << std::endl;
 //
-//    mat E;
-//    copy(Ecv, E);
-//
-//    // (см. Hartley & Zisserman p.258)
-//
-//    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//    mat U = svd.matrixU();
-//    vec s = svd.singularValues();
-//    mat V = svd.matrixV();
-//
-//    // U, V must be rotation matrices, not just orthogonal
-//    if (U.determinant() < 0) U = -U;
-//    if (V.determinant() < 0) V = -V;
-//
-//    std::cout << "U:\n" << U << std::endl;
-//    std::cout << "s:\n" << s << std::endl;
-//    std::cout << "V:\n" << V << std::endl;
-//
-//
-//    mat R0 = TODO;
-//    mat R1 = TODO;
-//
-//    std::cout << "R0:\n" << R0 << std::endl;
-//    std::cout << "R1:\n" << R1 << std::endl;
-//
-//    vec t0 = TODO;
-//    vec t1 = TODO;
-//
-//    std::cout << "t0:\n" << t0 << std::endl;
-//
-//    P0 = matrix34d::eye();
-//
-//    // 4 possible solutions
-//    matrix34d P10 = composeP(R0, t0);
-//    matrix34d P11 = composeP(R0, t1);
-//    matrix34d P12 = composeP(R1, t0);
-//    matrix34d P13 = composeP(R1, t1);
-//    matrix34d P1s[4] = {P10, P11, P12, P13};
-//
-//    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
-//    int best_count = 0;
-//    int best_idx = -1;
-//    for (int i = 0; i < 4; ++i) {
-//        int count = 0;
-//        for (int j = 0; j < (int) m0.size(); ++j) {
-//            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
-//                ++count;
-//            }
-//        }
-//        std::cout << "decomposeEMatrix: count: " << count << std::endl;
-//        if (count > best_count) {
-//            best_count = count;
-//            best_idx = i;
-//        }
-//    }
-//
-//    if (best_count == 0) {
-//        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
-//    }
-//
-//    P1 = P1s[best_idx];
-//
-//    std::cout << "best idx: " << best_idx << std::endl;
-//    std::cout << "P0: \n" << P0 << std::endl;
-//    std::cout << "P1: \n" << P1 << std::endl;
+    P0 = matrix34d::eye();
+
+    // 4 possible solutions
+    matrix34d P10 = composeP(R0, t0);
+    matrix34d P11 = composeP(R0, t1);
+    matrix34d P12 = composeP(R1, t0);
+    matrix34d P13 = composeP(R1, t1);
+    matrix34d P1s[4] = {P10, P11, P12, P13};
+
+    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
+    int best_count = 0;
+    int best_idx = -1;
+    for (int i = 0; i < 4; ++i) {
+        int count = 0;
+        for (int j = 0; j < (int) m0.size(); ++j) {
+            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
+                ++count;
+            }
+        }
+        std::cout << "decomposeEMatrix: count: " << count << std::endl;
+        if (count > best_count) {
+            best_count = count;
+            best_idx = i;
+        }
+    }
+
+    if (best_count == 0) {
+        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
+    }
+
+    P1 = P1s[best_idx];
+
+    std::cout << "best idx: " << best_idx << std::endl;
+    std::cout << "P0: \n" << P0 << std::endl;
+    std::cout << "P1: \n" << P1 << std::endl;
 }
 
 void phg::decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Matx34d &P)

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -20,8 +20,10 @@ namespace {
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
         //throw std::runtime_error("not implemented yet");
         Eigen::Matrix<double, 3, 3> newD;
-        newD(0, 0) = svd.singularValues()[0];
-        newD(1, 1) = svd.singularValues()[0];
+        newD.setZero();
+        newD(0, 0) = 1;//svd.singularValues()[0];
+        newD(1, 1) = 1;//svd.singularValues()[0];
+        std::cout << "newD2" << newD << "\n";
 
         E = svd.matrixU() * newD * svd.matrixV().transpose();
         copy(E, Ecv);
@@ -32,7 +34,7 @@ namespace {
 cv::Matx33d phg::fmatrix2ematrix(const cv::Matx33d &F, const phg::Calibration &calib0, const phg::Calibration &calib1)
 {
 //    throw std::runtime_error("not implemented yet");
-    matrix3d E = calib0.K().t() * F * calib1.K();
+    matrix3d E = calib1.K().t() * F * calib0.K();
 //
     ensureSpectralProperty(E);
 //
@@ -78,7 +80,7 @@ namespace {
         }
 
         // точка должна иметь положительную глубину для обеих камер
-        return calib0.project(P0 * X)[2] > 0 && calib1.project(P1 * X)[2] > 0;
+        return calib0.project(P0 * X)[2] > 0 && calib0.project(P1 * X)[2] > 0;
     }
 }
 
@@ -119,6 +121,11 @@ void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &
     std::cout << "V:\n" << V << std::endl;
 
     mat W(3, 3);
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            W(i, j) = 0;
+        }
+    }
     W(0, 1) = -1;
     W(1, 0) = 1;
     W(2, 2) = 1;

--- a/src/phg/sfm/fmatrix.cpp
+++ b/src/phg/sfm/fmatrix.cpp
@@ -25,49 +25,79 @@ namespace {
     // (см. Hartley & Zisserman p.279)
     cv::Matx33d estimateFMatrixDLT(const cv::Vec2d *m0, const cv::Vec2d *m1, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        int a_rows = TODO;
-//        int a_cols = TODO;
+        //throw std::runtime_error("not implemented yet");
+        int a_rows = count;
+        int a_cols = 9;
 //
-//        Eigen::MatrixXd A(a_rows, a_cols);
+        Eigen::MatrixXd A(a_rows, a_cols);
+
+        for (int i_pair = 0; i_pair < count; ++i_pair) {
+
+            double x0 = m0[i_pair][0];
+            double y0 = m0[i_pair][1];
+
+            double x1 = m1[i_pair][0];
+            double y1 = m1[i_pair][1];
+
+//            std::cout << "(" << x0 << ", " << y0 << "), (" << x1 << ", " << y1 << ")" << std::endl;
+
+            A(i_pair, 0) = x1 * x0;
+            A(i_pair, 1) = x1 * y0;
+            A(i_pair, 2) = x1;
+            A(i_pair, 3) = y1 * x0;
+            A(i_pair, 4) = y1 * y0;
+            A(i_pair, 5) = y1;
+            A(i_pair, 6) = x0;
+            A(i_pair, 7) = y0;
+            A(i_pair, 8) = 1;
+        }
 //
-//        for (int i_pair = 0; i_pair < count; ++i_pair) {
+        Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        Eigen::VectorXd null_space = svda.matrixV().col(8);
 //
-//            double x0 = m0[i_pair][0];
-//            double y0 = m0[i_pair][1];
+        Eigen::MatrixXd F(3, 3);
+        F.row(0) << null_space[0], null_space[1], null_space[2];
+        F.row(1) << null_space[3], null_space[4], null_space[5];
+        F.row(2) << null_space[6], null_space[7], null_space[8];
+
+//             Поправить F так, чтобы соблюдалось свойство фундаментальной матрицы (последнее сингулярное значение = 0)
+        Eigen::JacobiSVD<Eigen::MatrixXd> svdf(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+        Eigen::Matrix<double, 3, 3> newD;
+        //Eigen::DiagonalMatrix<double, 3> newD;
+        newD(0, 0) = svdf.singularValues()[0];
+        newD(1, 1) = svdf.singularValues()[1];
+        F = svdf.matrixU() * newD * svdf.matrixV().transpose();
 //
-//            double x1 = m1[i_pair][0];
-//            double y1 = m1[i_pair][1];
-//
-////            std::cout << "(" << x0 << ", " << y0 << "), (" << x1 << ", " << y1 << ")" << std::endl;
-//
-//            TODO
-//        }
-//
-//        Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//        Eigen::VectorXd null_space = TODO
-//
-//        Eigen::MatrixXd F(3, 3);
-//        F.row(0) << null_space[0], null_space[1], null_space[2];
-//        F.row(1) << null_space[3], null_space[4], null_space[5];
-//        F.row(2) << null_space[6], null_space[7], null_space[8];
-//
-////             Поправить F так, чтобы соблюдалось свойство фундаментальной матрицы (последнее сингулярное значение = 0)
-//        Eigen::JacobiSVD<Eigen::MatrixXd> svdf(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//          TODO
-//
-//        cv::Matx33d Fcv;
-//        copy(F, Fcv);
-//
-//        return Fcv;
+        cv::Matx33d Fcv;
+        copy(F, Fcv);
+
+        return Fcv;
     }
 
     // Нужно создать матрицу преобразования, которая сдвинет переданное множество точек так, что центр масс перейдет в ноль, а Root Mean Square расстояние до него станет sqrt(2)
     // (см. Hartley & Zisserman p.107 Why is normalization essential?)
     cv::Matx33d getNormalizeTransform(const std::vector<cv::Vec2d> &m)
     {
-        throw std::runtime_error("not implemented yet");
+        cv::Matx33d transMat = cv::Matx33d::zeros();
+        transMat(2, 2) = 1;
+
+        for (int i = 0; i < 2; i++) {
+            double curMean = 0;
+            for (const auto & j : m) {
+                curMean += j[i];
+            }
+            curMean /= m.size();
+            double std = 0;
+            for (const auto & j : m)
+                std += (j[i] - curMean) * (j[i] - curMean);
+            std = std::sqrt(std / m.size());
+            transMat(i, i) = std::sqrt(2) / std;
+            transMat(3, i) = transMat(i, i) * curMean * (-1);
+        }
+
+        return transMat;
+        //throw std::runtime_error("not implemented yet");
     }
 
     cv::Vec2d transformPoint(const cv::Vec2d &pt, const cv::Matx33d &T)
@@ -104,61 +134,61 @@ namespace {
             getNormalizeTransform(m0_t);
             getNormalizeTransform(m1_t);
         }
-        throw std::runtime_error("not implemented yet");
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
+//        throw std::runtime_error("not implemented yet");
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_trials = 100'000;
+
+        const int n_samples = 8;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx33d best_F;
 //
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_matches, n_samples, &seed);
+
+            cv::Vec2d ms0[n_samples];
+            cv::Vec2d ms1[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                ms0[i] = m0_t[sample[i]];
+                ms1[i] = m1_t[sample[i]];
+            }
+
+            cv::Matx33d F = estimateFMatrixDLT(ms0, ms1, n_samples);
+
+            // denormalize
+            F = (TN1.t() * F * TN0).t();
 //
-//        int best_support = 0;
-//        cv::Matx33d best_F;
+            int support = 0;
+            for (int i = 0; i < n_matches; ++i) {
+                if (phg::epipolarTest(m0[i], m1[i], F, threshold_px) && phg::epipolarTest(m1[i], m0[i], F.t(), threshold_px))
+                {
+                    ++support;
+                }
+            }
 //
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_matches, n_samples, &seed);
-//
-//            cv::Vec2d ms0[n_samples];
-//            cv::Vec2d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = m0_t[sample[i]];
-//                ms1[i] = m1_t[sample[i]];
-//            }
-//
-//            cv::Matx33d F = estimateFMatrixDLT(ms0, ms1, n_samples);
-//
-//            // denormalize
-//            F = TODO
-//
-//            int support = 0;
-//            for (int i = 0; i < n_matches; ++i) {
-//                if (phg::epipolarTest(m0[i], m1[i], todo, threshold_px) && phg::epipolarTest(m1[i], m0[i], todo, threshold_px))
-//                {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_F = F;
-//
-//                std::cout << "estimateFMatrixRANSAC : support: " << best_support << "/" << n_matches << std::endl;
-//                infoF(F);
-//
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateFMatrixRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateFMatrixRANSAC : failed to estimate fundamental matrix");
-//        }
-//
-//        return best_F;
+            if (support > best_support) {
+                best_support = support;
+                best_F = F;
+
+                std::cout << "estimateFMatrixRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+                infoF(F);
+
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateFMatrixRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateFMatrixRANSAC : failed to estimate fundamental matrix");
+        }
+
+        return best_F;
     }
 
 }

--- a/src/phg/sfm/homography.cpp
+++ b/src/phg/sfm/homography.cpp
@@ -84,8 +84,8 @@ namespace {
             double w1 = ws1[i];
 
             // 8 elements of matrix + free term as needed by gauss routine
-//            A.push_back({TODO});
-//            A.push_back({TODO});
+            A.push_back({0.f, 0.f, 0.f, -w1 * x0, -w1 * y0, -w1 * w0, y1 * x0, y1 * y0, -y1 * w0});
+            A.push_back({w1 * x0, w1 * y0, w1 * w0, 0.f, 0.f, 0.f, -x1 * x0, -x1 * y0, x1 * w0});
         }
 
         int res = gauss(A, H);
@@ -168,57 +168,57 @@ namespace {
         // * (простое описание для понимания)
         // * [3] http://ikrisoft.blogspot.com/2015/01/ransac-with-contrario-approach.html
 
-//        const int n_matches = points_lhs.size();
+        const int n_matches = points_lhs.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        const int n_trials = 50;
 //
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        const int n_trials = TODO;
+        const int n_samples = 4;
+        uint64_t seed = 1;
+        const double reprojection_error_threshold_px = 2;
 //
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//        const double reprojection_error_threshold_px = 2;
+        int best_support = 0;
+        cv::Mat best_H;
 //
-//        int best_support = 0;
-//        cv::Mat best_H;
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            randomSample(sample, n_matches, n_samples, &seed);
 //
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            randomSample(sample, n_matches, n_samples, &seed);
+            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
+                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
 //
-//            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
-//                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
+            int support = 0;
+            for (int i_point = 0; i_point < n_matches; ++i_point) {
+                try {
+                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
+                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
+                        ++support;
+                    }
+                } catch (const std::exception &e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
 //
-//            int support = 0;
-//            for (int i_point = 0; i_point < n_matches; ++i_point) {
-//                try {
-//                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
-//                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
-//                        ++support;
-//                    }
-//                } catch (const std::exception &e)
-//                {
-//                    std::cerr << e.what() << std::endl;
-//                }
-//            }
+            if (support > best_support) {
+                best_support = support;
+                best_H = H;
+
+                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
 //
-//            if (support > best_support) {
-//                best_support = support;
-//                best_H = H;
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
 //
-//                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
 //
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
+        if (best_support == 0) {
+            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
+        }
 //
-//        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
-//        }
-//
-//        return best_H;
+        return best_H;
     }
 
 }
@@ -238,7 +238,11 @@ cv::Mat phg::findHomographyCV(const std::vector<cv::Point2f> &points_lhs, const 
 // таким преобразованием внутри занимается функции cv::perspectiveTransform и cv::warpPerspective
 cv::Point2d phg::transformPoint(const cv::Point2d &pt, const cv::Mat &T)
 {
-    throw std::runtime_error("not implemented yet");
+    double v[3][1] = {{pt.x}, {pt.y}, {1.0}};
+    cv::Mat tr = T * cv::Mat(3, 1, CV_64F, v);
+    //cv::Mat tr = T * cv::Mat(3, 1, CV_64F, {{pt.x}, {pt.y}, {1.0}});
+    double w = tr.at<double>(2, 0);
+    return cv::Point2d{tr.at<double>(0, 0) / w, tr.at<double>(1, 0) / w};
 }
 
 cv::Point2d phg::transformPointCV(const cv::Point2d &pt, const cv::Mat &T) {

--- a/src/phg/sfm/panorama_stitcher.cpp
+++ b/src/phg/sfm/panorama_stitcher.cpp
@@ -3,6 +3,7 @@
 
 #include <libutils/bbox2.h>
 #include <iostream>
+#include <stack>
 
 /*
  * imgs - список картинок
@@ -23,7 +24,25 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
     {
         // здесь надо посчитать вектор Hs
         // при этом можно обойтись n_images - 1 вызовами функтора homography_builder
-        throw std::runtime_error("not implemented yet");
+        std::vector<bool> used(n_images);
+        for (int v = 0; v < n_images; v++) {
+            int cur_v = v;
+            std::stack<int> way;
+            while (cur_v != -1 && !used[cur_v]) {
+                way.push(cur_v);
+                cur_v = parent[cur_v];
+            }
+            while (!way.empty()) {
+                cur_v = way.top();
+                way.pop();
+                if (parent[cur_v] == -1) {
+                    Hs[cur_v] = cv::Mat::eye(3, 3, CV_64F);
+                } else {
+                    Hs[cur_v] = Hs[parent[cur_v]] * homography_builder(imgs[cur_v], imgs[parent[cur_v]]);
+                }
+                used[cur_v] = true;
+            }
+        }
     }
 
     bbox2<double, cv::Point2d> bbox;
@@ -46,19 +65,19 @@ cv::Mat phg::stitchPanorama(const std::vector<cv::Mat> &imgs,
     // из-за растяжения пикселей при использовании прямой матрицы гомографии после отображения между пикселями остается пустое пространство
     // лучше использовать обратную и для каждого пикселя на итоговвой картинке проверять, с какой картинки он может получить цвет
     // тогда в некоторых пикселях цвет будет дублироваться, но изображение будет непрерывным
-//        for (int i = 0; i < n_images; ++i) {
-//            for (int y = 0; y < imgs[i].rows; ++y) {
-//                for (int x = 0; x < imgs[i].cols; ++x) {
-//                    cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
-//
-//                    cv::Point2d pt_dst = applyH(cv::Point2d(x, y), Hs[i]) - bbox.min();
-//                    int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
-//                    int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
-//
-//                    result.at<cv::Vec3b>(y_dst, x_dst) = color;
-//                }
-//            }
-//        }
+        for (int i = 0; i < n_images; ++i) {
+            for (int y = 0; y < imgs[i].rows; ++y) {
+                for (int x = 0; x < imgs[i].cols; ++x) {
+                    cv::Vec3b color = imgs[i].at<cv::Vec3b>(y, x);
+
+                    cv::Point2d pt_dst = phg::transformPoint(cv::Point2d(x, y), Hs[i]) - bbox.min();
+                    int y_dst = std::max(0, std::min((int) std::round(pt_dst.y), result_height - 1));
+                    int x_dst = std::max(0, std::min((int) std::round(pt_dst.x), result_width - 1));
+
+                    result.at<cv::Vec3b>(y_dst, x_dst) = color;
+                }
+            }
+        }
 
     std::vector<cv::Mat> Hs_inv;
     std::transform(Hs.begin(), Hs.end(), std::back_inserter(Hs_inv), [&](const cv::Mat &H){ return H.inv(); });

--- a/src/phg/sfm/resection.cpp
+++ b/src/phg/sfm/resection.cpp
@@ -49,95 +49,112 @@ namespace {
     // (см. Hartley & Zisserman p.178)
     cv::Matx34d estimateCameraMatrixDLT(const cv::Vec3d *Xs, const cv::Vec3d *xs, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        using mat = Eigen::MatrixXd;
-//        using vec = Eigen::VectorXd;
+//        throw std::runtime_error("not implemented yet");
+        using mat = Eigen::MatrixXd;
+        using vec = Eigen::VectorXd;
+
+        mat A(count * 2, 12);
 //
-//        mat A(TODO);
+        for (int i = 0; i < count; ++i) {
+
+            double x = xs[i][0];
+            double y = xs[i][1];
+            double w = xs[i][2];
+
+            double X = Xs[i][0];
+            double Y = Xs[i][1];
+            double Z = Xs[i][2];
+            double W = 1.0;
+
+            std::vector<double> B {X, Y, Z, W};
+            for (int j = 0; j < 4; j++) {
+                A(i * 2, j) = w * B[j] * (-1);
+                A(i * 2 + 1, j + 4) = w * B[j] * (-1);
+                A(i * 2, j + 4) = 0;
+                A(i * 2 + 1, j) = 0;
+            }
+            for (int j = 8; j < 12; j++) {
+                A(i * 2, j) = x * B[j % 4];
+                A(i * 2 + 1, j) = y * B[j % 4];
+            }
+        }
 //
-//        for (int i = 0; i < count; ++i) {
+        matrix34d result;
+        Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 4; j++) {
+                result(i, j) = svd.matrixV().col(11)[i * 4 + j];
+            }
+        }
 //
-//            double x = xs[i][0];
-//            double y = xs[i][1];
-//            double w = xs[i][2];
-//
-//            double X = Xs[i][0];
-//            double Y = Xs[i][1];
-//            double Z = Xs[i][2];
-//            double W = 1.0;
-//
-//            TODO
-//        }
-//
-//        matrix34d result;
-//          TODO
-//
-//        return canonicalizeP(result);
+        return canonicalizeP(result);
     }
 
 
     // По трехмерным точкам и их проекциям на изображении определяем положение камеры
     cv::Matx34d estimateCameraMatrixRANSAC(const phg::Calibration &calib, const std::vector<cv::Vec3d> &X, const std::vector<cv::Vec2d> &x)
     {
-        throw std::runtime_error("not implemented yet");
-//        if (X.size() != x.size()) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
-//        }
+//        throw std::runtime_error("not implemented yet");
+        if (X.size() != x.size()) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
+        }
+
+        const int n_points = X.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_trials = 100'000;
+
+        const double threshold_px = 3;
+
+        const int n_samples = 6;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx34d best_P;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_points, n_samples, &seed);
+
+            cv::Vec3d ms0[n_samples];
+            cv::Vec3d ms1[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                ms0[i] = X[sample[i]];
+                ms1[i] = calib.unproject(x[sample[i]]);
+            }
 //
-//        const int n_points = X.size();
+            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
+
+            int support = 0;
+            for (int i = 0; i < n_points; ++i) {
+                //спроецировать 3Д точку в пиксель с использованием P и calib;
+                vector3d p3 = calib.project(P * vector4d(X[i][0], X[i][1], X[i][2], 1));
+                cv::Vec2d px(p3[0] / p3[2], p3[1] / p3[2]);
+                if (cv::norm(px - x[i]) < threshold_px) {
+                    ++support;
+                }
+            }
 //
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
-//
-//        const double threshold_px = 3;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//
-//        int best_support = 0;
-//        cv::Matx34d best_P;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_points, n_samples, &seed);
-//
-//            cv::Vec3d ms0[n_samples];
-//            cv::Vec3d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = TODO;
-//                ms1[i] = TODO;
-//            }
-//
-//            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
-//
-//            int support = 0;
-//            for (int i = 0; i < n_points; ++i) {
-//                cv::Vec2d px = TODO спроецировать 3Д точку в пиксель с использованием P и calib;
-//                if (cv::norm(px - x[i]) < threshold_px) {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_P = P;
-//
-//                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
-//
-//                if (best_support == n_points) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
-//        }
-//
-//        return best_P;
+            if (support > best_support) {
+                best_support = support;
+                best_P = P;
+
+                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
+
+                if (best_support == n_points) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
+        }
+
+        return best_P;
     }
 
 

--- a/src/phg/sfm/sfm_utils.cpp
+++ b/src/phg/sfm/sfm_utils.cpp
@@ -41,5 +41,7 @@ void phg::randomSample(std::vector<int> &dst, int max_id, int sample_size, uint6
 // проверяет, что расстояние от точки до линии меньше порога
 bool phg::epipolarTest(const cv::Vec2d &pt0, const cv::Vec2d &pt1, const cv::Matx33d &F, double t)
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Vec3d line = F * cv::Vec3d(pt0[0], pt0[1], 1);
+    return t > std::abs(pt1[0] * line[0] + pt1[1] * line[1] + line[2]) / std::sqrt(line[0] * line[0] + line[1] * line[1]);
+    //throw std::runtime_error("not implemented yet");
 }

--- a/src/phg/sfm/triangulation.cpp
+++ b/src/phg/sfm/triangulation.cpp
@@ -12,5 +12,34 @@ cv::Vec4d phg::triangulatePoint(const cv::Matx34d *Ps, const cv::Vec3d *ms, int 
 {
     // составление однородной системы + SVD
     // без подвохов
-    throw std::runtime_error("not implemented yet");
+//    throw std::runtime_error("not implemented yet");
+    int eq_num = count * 2;
+    Eigen::MatrixXd A(eq_num, 3);
+    Eigen::VectorXd b(eq_num);
+
+    for (int i_pair = 0; i_pair < eq_num / 2; ++i_pair) {
+        double x = ms[i_pair][0];
+        double y = ms[i_pair][1];
+        double z = ms[i_pair][2];
+        auto psCur = Ps[i_pair];
+
+        for (int i = 0; i < 3; i++) {
+            A(i_pair * 2, i) = x * psCur(2, i) - z * psCur(0, i);
+            A(i_pair * 2 + 1, i) = y * psCur(2, i) - z * psCur(1, i);
+        }
+
+        b(i_pair * 2) = z * psCur(0, 3) - x * psCur(2, 3);
+        b(i_pair * 2+ 1) = z * psCur(1, 3) - y * psCur(2, 3);
+    }
+
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+    Eigen::MatrixXd newD(3, eq_num);
+    newD.setZero();
+    for (int i = 0; i < 3; i++) {
+        newD(i, i) = 1 / svd.singularValues()[i];
+    }
+    Eigen::VectorXd sol = svd.matrixV() * newD * svd.matrixU().transpose() * b;
+
+    return cv::Vec4d(sol[0], sol[1], sol[2], 1);
 }

--- a/src/phg/sift/sift.cpp
+++ b/src/phg/sift/sift.cpp
@@ -24,16 +24,18 @@
 #define INITIAL_IMG_SIGMA           0.75                 // предполагаемая степень размытия изначальной картинки
 #define INPUT_IMG_PRE_BLUR_SIGMA    1.0                  // сглаживание изначальной картинки
    
-#define SUBPIXEL_FITTING_ENABLE      0    // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
+#define SUBPIXEL_FITTING_ENABLE      1    // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
 
 #define ORIENTATION_NHISTS           36   // число корзин при определении ориентации ключевой точки через гистограммы
 #define ORIENTATION_WINDOW_R         3    // минимальный радиус окна в рамках которого будет выбрана ориентиация (в пикселях), R=3 => 5x5 окно
-#define ORIENTATION_VOTES_PEAK_RATIO 0.80 // 0.8 => если гистограмма какого-то направления получила >= 80% от максимального чиссла голосов - она тоже победила
+#define ORIENTATION_VOTES_PEAK_RATIO 0.99 // 0.8 => если гистограмма какого-то направления получила >= 80% от максимального чиссла голосов - она тоже победила
 
 #define DESCRIPTOR_SIZE            4 // 4x4 гистограммы декскриптора
 #define DESCRIPTOR_NBINS           8 // 8 корзин-направлений в каждой гистограмме дескриптора (4х4 гистограммы, каждая по 8 корзин, итого 4x4x8=128 значений в дескрипторе)
 #define DESCRIPTOR_SAMPLES_N       4 // 4x4 замера для каждой гистограммы дескриптора (всего гистограмм 4х4) итого 16х16 замеров
 #define DESCRIPTOR_SAMPLE_WINDOW_R 1.0 // минимальный радиус окна в рамках которого строится гистограмма из 8 корзин-направлений (т.е. для каждого из 16 элементов дескриптора), R=1 => 1x1 окно
+
+#define SMOOTH_FACTOR               0.25 // фактор сглаживания
 
 
 void phg::SIFT::detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc) {
@@ -79,41 +81,46 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
             int layer = 0;
             size_t prevOctave = octave - 1;
             // берем картинку с предыдущей октавы и уменьшаем ее в два раза без какого бы то ни было дополнительного размытия (сигмы должны совпадать)
-            // cv::Mat img = gaussianPyramid[ TODO ].clone();
+            cv::Mat img = gaussianPyramid[ prevOctave * OCTAVE_GAUSSIAN_IMAGES + layer ].clone();
             // тут есть очень важный момент, мы должны указать fx=0.5, fy=0.5 иначе при нечетном размере картинка будет не идеально 2 пикселя в один схлопываться - а слегка смещаться
-            // cv::resize(img, img, cv::Size( TODO , TODO ), 0.5, 0.5, cv::INTER_NEAREST);
-            // gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
+            cv::resize(img, img, cv::Size(/*can use default here!*/), 0.5, 0.5, cv::INTER_NEAREST);
+            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
         }
 
-//        #pragma omp parallel for // TODO: если выполните TODO про "размытие из изначального слоя октавы" ниже - раскоментируйте это распараллеливание, ведь теперь слои считаются независимо (из самого первого), проверьте что результат на картинках не изменился
+        #pragma omp parallel for // OK: если выполните про "размытие из изначального слоя октавы" ниже - раскоментируйте это распараллеливание, ведь теперь слои считаются независимо (из самого первого), проверьте что результат на картинках не изменился
         for (ptrdiff_t layer = 1; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
-            size_t prevLayer = layer - 1;
+            // size_t prevLayer = layer - 1;
 
             // если есть два последовательных гауссовых размытия с sigma1 и sigma2, то результат будет с sigma12=sqrt(sigma1^2 + sigma2^2) => sigma2=sqrt(sigma12^2-sigma1^2)
-            double sigmaPrev = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
-            double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
-            double sigma = sqrt(sigmaCur*sigmaCur - sigmaPrev*sigmaPrev);                // sigma2  - сигма которую надо добавить чтобы довести sigma1 до sigma12
+//            double sigmaPrev = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
+//            double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
+//            double sigma = sqrt(sigmaCur*sigmaCur - sigmaPrev*sigmaPrev);                // sigma2  - сигма которую надо добавить чтобы довести sigma1 до sigma12
             // посмотрите внимательно на формулу выше и решите как по мнению этой формулы соотносится сигма у первого А-слоя i-ой октавы
             // и сигма у одного из последних слоев Б предыдущей (i-1)-ой октавы из которого этот слой А был получен?
             // а как чисто идейно должны бы соотноситься сигмы размытия у двух картинок если картинка А была получена из картинки Б простым уменьшением в 2 раза?
 
-            // TODO: переделайте это добавочное размытие с варианта "размываем предыдущий слой" на вариант "размываем самый первый слой октавы до степени размытия сигмы нашего текущего слоя"
+            // OK: переделайте это добавочное размытие с варианта "размываем предыдущий слой" на вариант "размываем самый первый слой октавы до степени размытия сигмы нашего текущего слоя"
             // проверьте - картинки отладочного вывода выглядят один-в-один до/после? (посмотрите на них туда-сюда быстро мигая)
 
-            cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + prevLayer].clone();
+            double sigma0 = INITIAL_IMG_SIGMA * pow(2.0, octave);
+            double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
+            double sigma = sqrt(sigmaCur*sigmaCur - sigma0*sigma0);
+            cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES].clone();
             cv::Size automaticKernelSize = cv::Size(0, 0);
 
             cv::GaussianBlur(imgLayer, imgLayer, automaticKernelSize, sigma, sigma);
 
             gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = imgLayer;
+            //if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "octave_" + to_string(octave) + "_layer_" + to_string(layer) + ".png", imgLayer);
         }
     }
 
+    // Выводим картинки (тут можно будет сравнить)
     for (size_t octave = 0; octave < NOCTAVES; ++octave) {
         for (size_t layer = 0; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
             double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
-            if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "pyramid/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur) + ".png", gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer]);
-            // TODO: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
+            if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "pyramid/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur) + "_v2.png", gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer]);
+            // ANS: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
             // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера? 
         }
     }
@@ -136,26 +143,26 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
                     imgCurDoG.at<float>(j, i) = imgCurGaussian.at<float>(j, i) - imgPrevGaussian.at<float>(j, i);
                 }
             }
-            int dogLayer = layer - 1;
+            int dogLayer = prevLayer;
             DoGPyramid[octave * OCTAVE_DOG_IMAGES + dogLayer] = imgCurDoG;
         }
     }
 
     // нам нужны padding-картинки по краям октавы чтобы извлекать экстремумы, но в статье предлагается не s+2 а s+3: [lowe04] We must produce s + 3 images in the stack of blurred images for each octave, so that final extrema detection covers a complete octave
-    // TODO: почему OCTAVE_GAUSSIAN_IMAGES=(OCTAVE_NLAYERS + 3) а не например (OCTAVE_NLAYERS + 2)?
+    // ANS: почему OCTAVE_GAUSSIAN_IMAGES=(OCTAVE_NLAYERS + 3) а не например (OCTAVE_NLAYERS + 2)?
 
     for (size_t octave = 0; octave < NOCTAVES; ++octave) {
         for (size_t layer = 0; layer < OCTAVE_DOG_IMAGES; ++layer) {
             double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
             if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "pyramidDoG/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur) + ".png", DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer]);
-            // TODO: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
+            // ANS: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
             // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы DoG? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера? 
         }
     }
 }
 
 namespace {
-    float parabolaFitting(float x0, float x1, float x2) {
+    std::pair<float, float> parabolaFitting(float x0, float x1, float x2) {
         rassert((x1 >= x0 && x1 >= x2) || (x1 <= x0 && x1 <= x2), 12541241241241);
 
         // a*0^2+b*0+c=x0
@@ -171,8 +178,10 @@ namespace {
         float a = (x2-2.0f*x1+x0) / 2.0f;
         float b = x1 - x0 - a;
         // extremum is at -b/(2*a), but our system coordinate start (i) is at 1, so minus 1
-        float shift = - b / (2.0f * a) - 1.0f;
-        return shift;
+        float extremum = - b / (2.0f * a);
+        float shift = extremum - 1.0f;
+        float value = a * extremum * extremum + b * extremum + x0;
+        return {shift, value};
     }
 }
 
@@ -205,7 +214,10 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                         for (int dz = -1; dz <= 1 && (is_min || is_max); ++dz) {
                         for (int dy = -1; dy <= 1 && (is_min || is_max); ++dy) {
                         for (int dx = -1; dx <= 1 && (is_min || is_max); ++dx) {
-                            // TODO проверить является ли наш центр все еще экстремум по сравнению с соседом DoGs[1+dz].at<float>(j+dy, i+dx) ? (не забудьте учесть что один из соседов - это мы сами)
+                            // OK проверить является ли наш центр все еще экстремум по сравнению с соседом DoGs[1+dz].at<float>(j+dy, i+dx) ? (не забудьте учесть что один из соседов - это мы сами)
+                            if (dz == 0 && dx == 0 && dy == 0) continue; // если совпали с собой
+                            if (center > DoGs[1 + dz].at<float>(j + dy, i + dx)) is_min = false;
+                            if (center < DoGs[1 + dz].at<float>(j + dy, i + dx)) is_max = false;
                         }
                         }
                         }
@@ -219,15 +231,18 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                         float dx = 0.0f;
                         float dy = 0.0f;
                         float dvalue = 0.0f;
-                        // TODO сделать субпиксельное уточнение (хотя бы через параболу-фиттинг независимо по оси X и оси Y, но лучше через честный ряд Тейлора, матрицу Гессе и итеративное смещение если экстремум оказался в соседнем пикселе)
+                        // OK сделать субпиксельное уточнение (хотя бы через параболу-фиттинг независимо по оси X и оси Y, но лучше через честный ряд Тейлора, матрицу Гессе и итеративное смещение если экстремум оказался в соседнем пикселе)
 #if SUBPIXEL_FITTING_ENABLE // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
                         {
-                            // TODO
+                            float dValueX, dValueY;
+                            std::tie(dx, dValueX) = parabolaFitting(DoGs[1].at<float>(j, i-1), center, DoGs[1].at<float>(j, i+1));
+                            std::tie(dy, dValueY) = parabolaFitting(DoGs[1].at<float>(j-1, i), center, DoGs[1].at<float>(j+1, i));
+                            dvalue = (dValueX + dValueY) / 2;
                         }
 #endif
-                        // TODO сделать фильтрацию слабых точек по слабому контрасту
+                        // OK сделать фильтрацию слабых точек по слабому контрасту
                         float contrast = center + dvalue;
-                        if (contrast < contrast_threshold / OCTAVE_NLAYERS) // TODO почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?
+                        if (contrast < contrast_threshold / OCTAVE_NLAYERS) // ANS почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?
                             continue;
 
                         kp.pt = cv::Point2f((i + 0.5 + dx) * octave_downscale, (j + 0.5 + dy) * octave_downscale);
@@ -251,8 +266,10 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                             float value = votes[bin];
                             float nextValue = votes[(bin + 1) % ORIENTATION_NHISTS];
                             if (value > prevValue && value > nextValue && votes[bin] > biggestVote * ORIENTATION_VOTES_PEAK_RATIO) {
-                                // TODO добавьте уточнение угла наклона - может помочь определенная выше функция parabolaFitting(float x0, float x1, float x2)
-                                kp.angle = (bin + 0.5) * (360.0 / ORIENTATION_NHISTS);
+                                // OK добавьте уточнение угла наклона - может помочь определенная выше функция parabolaFitting(float x0, float x1, float x2)
+                                float fixedBin, tmp;
+                                std::tie(fixedBin, tmp) = parabolaFitting(prevValue, value, nextValue);
+                                kp.angle = (fixedBin + 0.5) * (360.0 / ORIENTATION_NHISTS);
                                 rassert(kp.angle >= 0.0 && kp.angle <= 360.0, 123512412412);
                                 
                                 std::vector<float> descriptor;
@@ -301,21 +318,25 @@ bool phg::SIFT::buildLocalOrientationHists(const cv::Mat &img, size_t i, size_t 
     for (size_t y = j - radius + 1; y < j + radius; ++y) {
         for (size_t x = i - radius + 1; x < i + radius; ++x) {
             // m(x, y)=(L(x + 1, y) − L(x − 1, y))^2 + (L(x, y + 1) − L(x, y − 1))^2
-            // double magnitude = TODO
+            double dx = img.at<float>(y, x+1) - img.at<float>(y, x-1);
+            double dy = img.at<float>(y+1, x) - img.at<float>(y-1, x);
+            double magnitude = dx * dx + dy * dy;
 
             // orientation == theta
             // atan( (L(x, y + 1) − L(x, y − 1)) / (L(x + 1, y) − L(x − 1, y)) )
-            // double orientation = TODO // подсказка - используйте atan2(dy, dx)
-//            orientation = orientation * 180.0 / M_PI;
-//            orientation = (orientation + 90.0);
-//            if (orientation <  0.0)   orientation += 360.0;
-//            if (orientation >= 360.0) orientation -= 360.0;
-//            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
-//            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
-//            size_t bin = TODO
-//            rassert(bin < ORIENTATION_NHISTS, 361236315613);
-//            sum[bin] += magnitude;
-            // TODO может быть сгладить получившиеся гистограммы улучшит результат? 
+            double orientation = atan2(dy, dx); // OK подсказка - используйте atan2(dy, dx)
+            orientation = orientation * 180.0 / M_PI;
+            orientation = (orientation + 90.0);
+            if (orientation <  0.0)   orientation += 360.0;
+            if (orientation >= 360.0) orientation -= 360.0;
+            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
+            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
+            size_t bin = orientation * ORIENTATION_NHISTS / 360.0;
+            rassert(bin < ORIENTATION_NHISTS, 361236315613);
+            sum[bin] += magnitude;// * (1 - SMOOTH_FACTOR * 2);
+            // OK может быть сгладить получившиеся гистограммы улучшит результат?
+//            sum[(bin - 1) % DESCRIPTOR_NBINS] += magnitude * SMOOTH_FACTOR;
+//            sum[(bin + 1) % DESCRIPTOR_NBINS] += magnitude * SMOOTH_FACTOR;
         }
     }
 
@@ -343,39 +364,46 @@ bool phg::SIFT::buildDescriptor(const cv::Mat &img, float px, float py, double d
                 for (int smpi = 0; smpi < DESCRIPTOR_SAMPLES_N; ++smpi) { // перебираем столбик очередного замера для текущей гистограммы
                     for (int smpy = 0; smpy < smpW; ++smpy) { // перебираем ряд пикселей текущего замера
                         for (int smpx = 0; smpx < smpW; ++smpx) { // перебираем столбик пикселей текущего замера
-//                            cv::Point2f shift(((-DESCRIPTOR_SIZE/2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW, TODO);
-//                            std::vector<cv::Point2f> shiftInVector(1, shift);
-//                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation); // преобразуем относительный сдвиг с учетом ориентации ключевой точки
-//                            shift = shiftInVector[0];
+                            cv::Point2f shift(((-DESCRIPTOR_SIZE/2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW, ((-DESCRIPTOR_SIZE/2.0 + hstj) * DESCRIPTOR_SAMPLES_N + smpj) * smpW);
+                            std::vector<cv::Point2f> shiftInVector(1, shift);
+                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation); // преобразуем относительный сдвиг с учетом ориентации ключевой точки
+                            shift = shiftInVector[0];
 
-//                            int x = (int) (px + shift.x);
-//                            int y = TODO;
+                            int x = (int) (px + shift.x);
+                            int y = (int) (py + shift.y);
 
-//                            if (y - 1 < 0 || y + 1 > img.rows || x - 1 < 0 || x + 1 > img.cols)
-//                                return false;
+                            if (y - 1 < 0 || y + 1 >= img.rows || x - 1 < 0 || x + 1 >= img.cols)
+                                return false;
 
-//                            double magnitude = TODO
+                            double dx = img.at<float>(y, x+1) - img.at<float>(y, x-1);
+                            double dy = img.at<float>(y+1, x) - img.at<float>(y-1, x);
+                            double magnitude = dx * dx + dy * dy;
+                            double orientation = atan2(dy, dx);
+                            orientation = orientation * 180.0 / M_PI;
+                            orientation = (orientation + 90.0) - angle;
+                            if (orientation <  0.0)   orientation += 360.0;
+                            if (orientation >= 360.0) orientation -= 360.0;
 
-//                            double orientation = atan2(TODO);
-//                            orientation = orientation * 180.0 / M_PI;
-//                            orientation = (orientation + 90.0);
-//                            if (orientation <  0.0)   orientation += 360.0;
-//                            if (orientation >= 360.0) orientation -= 360.0;
-
-                              // TODO за счет чего этот вклад будет сравниваться с этим же вкладом даже если эта картинка будет повернута? что нужно сделать с ориентацией каждого градиента из окрестности этой ключевой точки?
-
-//                            rassert(orientation >= 0.0 && orientation < 360.0, 3515215125412);
+                              // ANS за счет чего этот вклад будет сравниваться с этим же вкладом даже если эта картинка будет повернута? что нужно сделать с ориентацией каждого градиента из окрестности этой ключевой точки?
+                            //printf("%f %f %f %f %f %d %d\n", dx, dy, img.at<float>(y+1, x), img.at<float>(y-1, x), orientation, y, x);
+                            rassert(orientation >= 0.0 && orientation < 360.0, 3515215125412);
                             static_assert(360 % DESCRIPTOR_NBINS == 0, "Inappropriate bins number!");
-//                            size_t bin = TODO;
-//                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
-//                            sum[bin] += magnitude;
-                            // TODO хорошая идея добавить трилинейную интерполяцию как предложено в статье, или хотя бы сэмулировать ее - сгладить получившиеся гистограммы
+                            size_t bin = orientation * DESCRIPTOR_NBINS / 360.0;
+                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
+                            sum[bin] += magnitude;
+                            // OK хорошая идея добавить трилинейную интерполяцию как предложено в статье, или хотя бы сэмулировать ее - сгладить получившиеся гистограммы
+                            sum[(bin - 1) % DESCRIPTOR_NBINS] += SMOOTH_FACTOR * magnitude;
+                            sum[(bin + 1) % DESCRIPTOR_NBINS] += SMOOTH_FACTOR * magnitude;
                         }
                     }
                 }
             }
 
-            // TODO нормализовать наш вектор дескриптор (подсказка: посчитать его длину и поделить каждую компоненту на эту длину)
+            // OK нормализовать наш вектор дескриптор (подсказка: посчитать его длину и поделить каждую компоненту на эту длину)
+            float len = 0.0;
+            for (float s: sum) len += s * s;
+            len = std::sqrt(len);
+            for (float& s: sum) s /= len;
 
             float *votes = &(descriptor[(hstj * DESCRIPTOR_SIZE + hsti) * DESCRIPTOR_NBINS]); // нашли где будут лежать корзины нашей гистограммы
             for (int bin = 0; bin < DESCRIPTOR_NBINS; ++bin) {

--- a/src/phg/sift/sift.h
+++ b/src/phg/sift/sift.h
@@ -10,7 +10,7 @@ namespace phg {
     class SIFT {
     public:
         // Можете добавить дополнительных параметров со значениями по умолчанию в конструктор если хотите
-        SIFT(double contrast_threshold = 0.5) : contrast_threshold(contrast_threshold) {}
+        SIFT(double contrast_threshold = 2) : contrast_threshold(contrast_threshold) {}
 
         // Сигнатуру этого метода менять нельзя
         void detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc);

--- a/tests/test_matching.cpp
+++ b/tests/test_matching.cpp
@@ -17,10 +17,12 @@
 
 #include "utils/test_utils.h"
 
+#define DEBUG_ENABLE     0
+#define DEBUG_PATH       std::string("data/debug/test_matching/debug/")
 
 // TODO enable both toggles for testing custom detector & matcher
 #define ENABLE_MY_DESCRIPTOR 0
-#define ENABLE_MY_MATCHING 0
+#define ENABLE_MY_MATCHING 1
 #define ENABLE_GPU_BRUTEFORCE_MATCHER 0
 
 #if ENABLE_MY_MATCHING
@@ -234,6 +236,8 @@ TEST (MATCHING, SimpleStitching) {
 
     cv::Mat img1 = cv::imread("data/src/test_matching/hiking_left.JPG");
     cv::Mat img2 = cv::imread("data/src/test_matching/hiking_right.JPG");
+
+    if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "img1.png", img1);
 
     testStitchingMultipleDetectors(img1, img2);
 }

--- a/tests/test_sfm.cpp
+++ b/tests/test_sfm.cpp
@@ -18,7 +18,7 @@
 #include "utils/test_utils.h"
 
 
-#define ENABLE_MY_SFM 0
+#define ENABLE_MY_SFM 1
 
 namespace {
 

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -82,9 +82,9 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
     cv::randn(noise, cv::Scalar::all(0), cv::Scalar::all(GAUSSIAN_NOISE_STDDEV));
     cv::add(transformedImage, noise, transformedImage); // добавляем к преобразованной картинке гауссиан шума
     cv::Mat img1 = transformedImage;
-
+    printf("!!!!");
     {
-        for (int method = 0; method < 3; ++method) { // тестируем три метода: OpenCV ORB, OpenCV SIFT, ваш SIFT
+        for (int method = 2; method < 3; ++method) { // тестируем три метода: OpenCV ORB, OpenCV SIFT, ваш SIFT
             std::vector<cv::KeyPoint> kps0;
             std::vector<cv::KeyPoint> kps1;
 
@@ -116,12 +116,12 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                 detector->compute(img1, kps1, desc1);
             } else if (method == 2) {
                 // TODO remove 'return' and uncomment
-                return;
-//                method_name = "SIFT_MY";
-//                log_prefix = "[SIFT_MY] ";
-//                phg::SIFT mySIFT;
-//                mySIFT.detectAndCompute(img0, kps0, desc0);
-//                mySIFT.detectAndCompute(img1, kps1, desc1);
+                //return;
+                method_name = "SIFT_MY";
+                log_prefix = "[SIFT_MY] ";
+                phg::SIFT mySIFT;
+                mySIFT.detectAndCompute(img0, kps0, desc0);
+                mySIFT.detectAndCompute(img1, kps1, desc1);
             } else {
                 rassert(false, 13532513412); // это не проверка как часть тестирования, это проверка что число итераций в цикле и if-else ветки все еще согласованы и не разошлись
             }


### PR DESCRIPTION
1) Мы можем получить облако точек и взаимную ориентацию по двум камерам. Почему для выравнивания трёх камер мы использовали резекцию, а не посчитали E матрицу для второй пары камер и не разложили ее?
Если бы мы делали через E матрицу, то вычислений было бы больше. Это привело бы к потере точности по двум причинам:
1. просто любое вычисление на компьютере не может быть абсолютно точным, увеличение вычисление приводит к потенциальному увеличению погрешности
2. (и более важное, наверное) из-за зануления элемента для приведения матрицы к рангу 0 мы теряем в точности, здесь это проявилось бы ещё сильнее

2) Как реализовать выравнивание если мы все же хотим использовать Е матрицу?
Сначала найдём точки только для первых двух камер. Затем, почитав Е матрицу для третьей, получим относительное положение третьей камеры по сравнению с первой. После этого можем триангулировать те точки, которые видны первой и третьей камерой, а также пересчитать точки, которые видны всеми тремя камерами.