### PR TITLE
Task02 Артем Каширин СПбГУ

### DIFF
--- a/src/phg/matching/descriptor_matcher.cpp
+++ b/src/phg/matching/descriptor_matcher.cpp
@@ -12,7 +12,7 @@ void phg::DescriptorMatcher::filterMatchesRatioTest(const std::vector<std::vecto
 
 
     for (const auto & match : matches) {
-        if (match.size() == 1 || match[0].distance / match[1].distance < MATCH_RATIO) {
+        if (match.size() == 1 || match[0].distance < MATCH_RATIO * match[1].distance) {
             filtered_matches.push_back(match[0]);
         }
     }

--- a/src/phg/matching/descriptor_matcher.cpp
+++ b/src/phg/matching/descriptor_matcher.cpp
@@ -3,12 +3,19 @@
 #include <opencv2/flann/miniflann.hpp>
 #include "flann_factory.h"
 
+#define MATCH_RATIO 0.6
+
 void phg::DescriptorMatcher::filterMatchesRatioTest(const std::vector<std::vector<cv::DMatch>> &matches,
                                                     std::vector<cv::DMatch> &filtered_matches)
 {
     filtered_matches.clear();
 
-    throw std::runtime_error("not implemented yet");
+
+    for (const auto & match : matches) {
+        if (match.size() == 1 || match[0].distance / match[1].distance < MATCH_RATIO) {
+            filtered_matches.push_back(match[0]);
+        }
+    }
 }
 
 
@@ -35,42 +42,65 @@ void phg::DescriptorMatcher::filterMatchesClusters(const std::vector<cv::DMatch>
         points_query.at<cv::Point2f>(i) = keypoints_query[matches[i].queryIdx].pt;
         points_train.at<cv::Point2f>(i) = keypoints_train[matches[i].trainIdx].pt;
     }
-//
-//    // размерность всего 2, так что точное KD-дерево
-//    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(TODO);
-//    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(TODO);
-//
-//    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
-//    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
-//
-//    // для каждой точки найти total neighbors ближайших соседей
-//    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
-//    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
-//    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
-//
-//    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
-//    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
-//
-//    // оценить радиус поиска для каждой картинки
-//    // NB: radius2_query, radius2_train: квадраты радиуса!
-//    float radius2_query, radius2_train;
-//    {
-//        std::vector<double> max_dists2_query(n_matches);
-//        std::vector<double> max_dists2_train(n_matches);
-//        for (int i = 0; i < n_matches; ++i) {
-//            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
-//            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
-//        }
-//
-//        int median_pos = n_matches / 2;
-//        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
-//        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
-//
-//        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
-//        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
-//    }
-//
+
+    // размерность всего 2, так что точное KD-дерево
+    std::shared_ptr<cv::flann::IndexParams> index_params = flannKdTreeIndexParams(1);
+    std::shared_ptr<cv::flann::SearchParams> search_params = flannKsTreeSearchParams(n_matches);
+
+    std::shared_ptr<cv::flann::Index> index_query = flannKdTreeIndex(points_query, index_params);
+    std::shared_ptr<cv::flann::Index> index_train = flannKdTreeIndex(points_train, index_params);
+
+    // для каждой точки найти total neighbors ближайших соседей
+    cv::Mat indices_query(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_query(n_matches, total_neighbours, CV_32FC1);
+    cv::Mat indices_train(n_matches, total_neighbours, CV_32SC1);
+    cv::Mat distances2_train(n_matches, total_neighbours, CV_32FC1);
+
+    index_query->knnSearch(points_query, indices_query, distances2_query, total_neighbours, *search_params);
+    index_train->knnSearch(points_train, indices_train, distances2_train, total_neighbours, *search_params);
+
+    // оценить радиус поиска для каждой картинки
+    // NB: radius2_query, radius2_train: квадраты радиуса!
+    float radius2_query, radius2_train;
+    {
+        std::vector<double> max_dists2_query(n_matches);
+        std::vector<double> max_dists2_train(n_matches);
+        for (int i = 0; i < n_matches; ++i) {
+            max_dists2_query[i] = distances2_query.at<float>(i, total_neighbours - 1);
+            max_dists2_train[i] = distances2_train.at<float>(i, total_neighbours - 1);
+        }
+
+        int median_pos = n_matches / 2;
+        std::nth_element(max_dists2_query.begin(), max_dists2_query.begin() + median_pos, max_dists2_query.end());
+        std::nth_element(max_dists2_train.begin(), max_dists2_train.begin() + median_pos, max_dists2_train.end());
+
+        radius2_query = max_dists2_query[median_pos] * radius_limit_scale * radius_limit_scale;
+        radius2_train = max_dists2_train[median_pos] * radius_limit_scale * radius_limit_scale;
+    }
+
 //    метч остается, если левое и правое множества первых total_neighbors соседей в радиусах поиска(radius2_query, radius2_train) имеют как минимум consistent_matches общих элементов
-//    // TODO заполнить filtered_matches
+    for (int i = 0; i < matches.size(); i++) {
+        std::set<int> neigh_query_ids;
+        std::set<int> neigh_train_ids;
+
+        for (int j = 0; j < total_neighbours; j++) {
+            if (distances2_query.at<float>(i, j) < radius2_query) {
+                neigh_query_ids.insert(indices_query.at<int>(i, j));
+            }
+        }
+
+        for (int j = 0; j < total_neighbours; j++) {
+            if (distances2_train.at<float>(i, j) < radius2_train) {
+                neigh_train_ids.insert(indices_train.at<int>(i, j));
+            }
+        }
+
+        std::vector<int> intersection_ids;
+        std::set_intersection(neigh_query_ids.begin(), neigh_query_ids.end(),
+                              neigh_train_ids.begin(), neigh_train_ids.end(),
+                              std::back_inserter(intersection_ids));
+        if (intersection_ids.size() >= consistent_matches) {
+            filtered_matches.push_back(matches[i]);
+        }
+    }
 }

--- a/src/phg/matching/flann_matcher.cpp
+++ b/src/phg/matching/flann_matcher.cpp
@@ -6,8 +6,8 @@
 phg::FlannMatcher::FlannMatcher()
 {
     // параметры для приближенного поиска
-//    index_params = flannKdTreeIndexParams(TODO);
-//    search_params = flannKsTreeSearchParams(TODO);
+    index_params = flannKdTreeIndexParams(4);
+    search_params = flannKsTreeSearchParams(32);
 }
 
 void phg::FlannMatcher::train(const cv::Mat &train_desc)
@@ -17,5 +17,15 @@ void phg::FlannMatcher::train(const cv::Mat &train_desc)
 
 void phg::FlannMatcher::knnMatch(const cv::Mat &query_desc, std::vector<std::vector<cv::DMatch>> &matches, int k) const
 {
-    throw std::runtime_error("not implemented yet");
+//    throw std::runtime_error("not implemented yet");
+    cv::Mat indices, dists;
+    flann_index->knnSearch(query_desc, indices, dists, k, *search_params);
+
+    for (int i = 0; i < query_desc.rows; i++) {
+        std::vector<cv::DMatch> cur_matches;
+        for (int j = 0; j < k; j++) {
+            cur_matches.emplace_back(i, indices.at<int>(i, j), dists.at<float>(i, j));
+        }
+        matches.push_back(cur_matches);
+    }
 }

--- a/src/phg/sfm/homography.cpp
+++ b/src/phg/sfm/homography.cpp
@@ -84,8 +84,16 @@ namespace {
             double w1 = ws1[i];
 
             // 8 elements of matrix + free term as needed by gauss routine
-//            A.push_back({TODO});
-//            A.push_back({TODO});
+            A.push_back({
+                        0.0, 0.0, 0.0,
+                        -x0*w1, -y0*w1, -w0*w1,
+                        x0*y1, y0*y1, -w0*y1
+                });
+            A.push_back({
+                        x0*w1, y0*w1, w0*w1,
+                        0.0, 0.0, 0.0,
+                        -x0*x1, -y0*x1, w0*x1
+            });
         }
 
         int res = gauss(A, H);
@@ -168,57 +176,58 @@ namespace {
         // * (простое описание для понимания)
         // * [3] http://ikrisoft.blogspot.com/2015/01/ransac-with-contrario-approach.html
 
-//        const int n_matches = points_lhs.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        const int n_trials = TODO;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//        const double reprojection_error_threshold_px = 2;
-//
-//        int best_support = 0;
-//        cv::Mat best_H;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            randomSample(sample, n_matches, n_samples, &seed);
-//
-//            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
-//                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
-//
-//            int support = 0;
-//            for (int i_point = 0; i_point < n_matches; ++i_point) {
-//                try {
-//                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
-//                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
-//                        ++support;
-//                    }
-//                } catch (const std::exception &e)
-//                {
-//                    std::cerr << e.what() << std::endl;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_H = H;
-//
-//                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
-//
-//                if (best_support == n_matches) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
-//        }
-//
-//        return best_H;
+        const int n_matches = points_lhs.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // TODO numbers
+        const int n_trials = 4;
+
+        const int n_samples = 50;
+        uint64_t seed = 1;
+        const double reprojection_error_threshold_px = 2;
+
+        int best_support = 0;
+        cv::Mat best_H;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            randomSample(sample, n_matches, n_samples, &seed);
+
+            cv::Mat H = estimateHomography4Points(points_lhs[sample[0]], points_lhs[sample[1]], points_lhs[sample[2]], points_lhs[sample[3]],
+                                                  points_rhs[sample[0]], points_rhs[sample[1]], points_rhs[sample[2]], points_rhs[sample[3]]);
+
+            int support = 0;
+            for (int i_point = 0; i_point < n_matches; ++i_point) {
+                try {
+                    cv::Point2d proj = phg::transformPoint(points_lhs[i_point], H);
+                    if (cv::norm(proj - cv::Point2d(points_rhs[i_point])) < reprojection_error_threshold_px) {
+                        ++support;
+                    }
+                } catch (const std::exception &e)
+                {
+                    std::cerr << e.what() << std::endl;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_H = H;
+
+                std::cout << "estimateHomographyRANSAC : support: " << best_support << "/" << n_matches << std::endl;
+
+                if (best_support == n_matches) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateHomographyRANSAC : best support: " << best_support << "/" << n_matches << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateHomographyRANSAC : failed to estimate homography");
+        }
+
+        return best_H;
     }
 
 }
@@ -238,7 +247,9 @@ cv::Mat phg::findHomographyCV(const std::vector<cv::Point2f> &points_lhs, const 
 // таким преобразованием внутри занимается функции cv::perspectiveTransform и cv::warpPerspective
 cv::Point2d phg::transformPoint(const cv::Point2d &pt, const cv::Mat &T)
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Mat transformed = T * cv::Vec3d(pt.x, pt.y, 1.0);
+    double w = transformed.at<double>(2, 0);
+    return cv::Point2d(transformed.at<double>(0,0) / w, transformed.at<double>(1, 0) / w);
 }
 
 cv::Point2d phg::transformPointCV(const cv::Point2d &pt, const cv::Mat &T) {

--- a/tests/test_matching.cpp
+++ b/tests/test_matching.cpp
@@ -20,7 +20,7 @@
 
 // TODO enable both toggles for testing custom detector & matcher
 #define ENABLE_MY_DESCRIPTOR 0
-#define ENABLE_MY_MATCHING 0
+#define ENABLE_MY_MATCHING 1
 #define ENABLE_GPU_BRUTEFORCE_MATCHER 0
 
 #if ENABLE_MY_MATCHING

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -225,7 +225,6 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
             std::cout << log_prefix << "average size ratio between matched points: " << (size_ratio_sum / n_matched) << std::endl;
             if (angle_diff_sum != 0.0) {
                 std::cout << log_prefix << "average angle difference between matched points: " << (angle_diff_sum / n_matched) << " degrees" << std::endl;
-                // TODO почему SIFT менее точно угадывает средний угол отклонения? изменяется ли ситуация если выкрутить параметр ORIENTATION_VOTES_PEAK_RATIO=0.999? почему?
             }
             if (desc_dist_sum != 0.0 && desc_rand_dist_sum != 0.0) {
                 std::cout << log_prefix << "average descriptor distance between matched points: " << (desc_dist_sum / n_matched) << " (random distance: " << (desc_rand_dist_sum / n_matched) << ") => differentiability=" << (desc_dist_sum / desc_rand_dist_sum) << std::endl;

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -1,5 +1,3 @@
-#pragma clang diagnostic push
-#pragma ide diagnostic ignored "openmp-use-default-none"
 #include <gtest/gtest.h>
 
 #include <opencv2/core.hpp>
@@ -423,5 +421,3 @@ TEST (SIFT, HerzJesu19RotateM40) {
     double minRecall = 0.75;
     evaluateDetection(cv::getRotationMatrix2D(cv::Point(jesu19.cols/2, jesu19.rows/2), -angleDegreesClockwise, scale), minRecall, jesu19);
 }
-
-#pragma clang diagnostic pop


### PR DESCRIPTION
1) Зачем фильтровать матчи, если потом мы запускаем устойчивый к выбросам RANSAC и отфильтровываем шумные сопоставления?
В противном случае часть итераций RANSAC уйдёт на фильтрацию шумов и выбросов; у нас фиксированное число итераций, и чем меньше мы тратим на фильтрацию, тем больше - на минимизацию ошибки.

2) Cluster filtering довольно хорошо работает и без Ratio test. Однако, если оставить только Cluster filtering, некоторые тесты начнут падать. Почему так происходит? В каких случаях наоборот, не хватает Ratio test и необходима дополнительная фильтрация?
Ratio test отбрасывает сопоставления, склонные к повторению. Без него Cluster filtering может совместить два повторения паттерна, что на самом деле не являются одной точкой.
Cluster Filtering позволяет сопоставить похожие участки. Ratio test может предоставить хорошо описывающий матч, который, однако, не учитывает своё окружение.

3) С какой проблемой можно столкнуться при приравнивании единице элемента H33 матрицы гомографии? Как ее решить?
Если H33 близок к нулю, то при приведении размер остальных элементов будет сильно расти. Матрица гомографии невырождена, поэтому к 1 можно приравнять элемент H32 или H31.

4) Какой подвох таится в попытке склеивать большие панорамы и ортофото методом, реализованным в данной домашке? (Для интуиции можно посмотреть на результат склейки, когда за корень взята какая-нибудь другая картинка)
Для дальних кадров получается слишком растягивающая гомография.

5) Как можно автоматически построить граф для построения панорамы, чтобы на вход метод принимал только список картинок?
Делаем полный граф (сопоставим каждые две картинки, рёбрам дадим вес по кол-ву матчей). На нём выберем максимальное остовное дерево.

<details><summary>Travis CI</summary><p>

<pre>
Running main() from /home/lenny/Documents/Learning/PhotogrammetryTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 20 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from MATCHING
[ RUN      ] MATCHING.SimpleStitching
testing sift detector/descriptor...
estimateHomographyRANSAC : support: 1005/1005
estimateHomographyRANSAC : best support: 1005/1005
keypoints RMSE: 0.116314, color RMSE: 5.6938
[       OK ] MATCHING.SimpleStitching (754 ms)
[ RUN      ] MATCHING.SimpleMatching
testing sift detector/descriptor...
flann matching...
cv flann matching...
brute force matching
BruteforceMatcher::knnMatch : n query desc : 3919, n train desc : 3522
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 1005/1005
estimateHomographyRANSAC : best support: 1005/1005
evaluating homography...
nn_score: 0.610615, nn2_score: 0.26716, nn_score_cv: 0.613167, nn2_score_cv: 0.266139, time_my: 0.066975, time_cv: 0.069743, time_bruteforce: 3.37232, good_nn: 0.260015, good_ratio: 0.970392, good_clusters: 0.996587, good_ratio_and_clusters: 0.999005
[       OK ] MATCHING.SimpleMatching (3835 ms)
[ RUN      ] MATCHING.Rotate10
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 755/758
estimateHomographyRANSAC : best support: 755/758
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.083735, time_cv: 0.087299, time_bruteforce: 0, good_nn: 0.180403, good_ratio: 0.870927, good_clusters: 0.917127, good_ratio_and_clusters: 0.912929
[       OK ] MATCHING.Rotate10 (660 ms)
[ RUN      ] MATCHING.Rotate20
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 766/766
estimateHomographyRANSAC : best support: 766/766
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.084526, time_cv: 0.084268, time_bruteforce: 0, good_nn: 0.201582, good_ratio: 0.941748, good_clusters: 0.967254, good_ratio_and_clusters: 0.994778
[       OK ] MATCHING.Rotate20 (650 ms)
[ RUN      ] MATCHING.Rotate30
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 750/751
estimateHomographyRANSAC : best support: 750/751
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.083707, time_cv: 0.082185, time_bruteforce: 0, good_nn: 0.182445, good_ratio: 0.880202, good_clusters: 0.913649, good_ratio_and_clusters: 0.921438
[       OK ] MATCHING.Rotate30 (638 ms)
[ RUN      ] MATCHING.Rotate40
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 754/754
estimateHomographyRANSAC : best support: 754/754
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.085386, time_cv: 0.081602, time_bruteforce: 0, good_nn: 0.196224, good_ratio: 0.949495, good_clusters: 0.9729, good_ratio_and_clusters: 0.984085
[       OK ] MATCHING.Rotate40 (644 ms)
[ RUN      ] MATCHING.Rotate45
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 685/765
estimateHomographyRANSAC : support: 764/765
estimateHomographyRANSAC : best support: 764/765
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.093161, time_cv: 0.08324, time_bruteforce: 0, good_nn: 0.199796, good_ratio: 0.95528, good_clusters: 0.982558, good_ratio_and_clusters: 0.993464
[       OK ] MATCHING.Rotate45 (683 ms)
[ RUN      ] MATCHING.Rotate90
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 631/831
estimateHomographyRANSAC : support: 830/831
estimateHomographyRANSAC : best support: 830/831
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.077879, time_cv: 0.073685, time_bruteforce: 0, good_nn: 0.210513, good_ratio: 0.936782, good_clusters: 0.959184, good_ratio_and_clusters: 0.968712
[       OK ] MATCHING.Rotate90 (627 ms)
[ RUN      ] MATCHING.Scale50
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 137/165
estimateHomographyRANSAC : support: 156/165
estimateHomographyRANSAC : best support: 156/165
evaluating homography...
too few matches: 0
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.042256, time_cv: 0.038656, time_bruteforce: 0, good_nn: 0.0283236, good_ratio: 0.5, good_clusters: 0, good_ratio_and_clusters: 0.624242
/home/lenny/Documents/Learning/PhotogrammetryTasks2023/tests/test_matching.cpp:624: Failure
Expected: (good_ratio) > (0.7), actual: 0.5 vs 0.7
/home/lenny/Documents/Learning/PhotogrammetryTasks2023/tests/test_matching.cpp:626: Failure
Expected: (good_ratio_and_clusters) > (0.7), actual: 0.624242 vs 0.7
[  FAILED  ] MATCHING.Scale50 (329 ms)
[ RUN      ] MATCHING.Scale70
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 375/376
estimateHomographyRANSAC : support: 376/376
estimateHomographyRANSAC : best support: 376/376
evaluating homography...
too few matches: 28
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.051874, time_cv: 0.050202, time_bruteforce: 0, good_nn: 0.0913498, good_ratio: 0.819477, good_clusters: 0, good_ratio_and_clusters: 0.909574
[       OK ] MATCHING.Scale70 (416 ms)
[ RUN      ] MATCHING.Scale90
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 657/657
estimateHomographyRANSAC : best support: 657/657
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.06732, time_cv: 0.066056, time_bruteforce: 1e-06, good_nn: 0.169686, good_ratio: 0.941945, good_clusters: 0.987854, good_ratio_and_clusters: 0.980213
[       OK ] MATCHING.Scale90 (562 ms)
[ RUN      ] MATCHING.Scale110
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 789/789
estimateHomographyRANSAC : best support: 789/789
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.094077, time_cv: 0.091355, time_bruteforce: 1e-06, good_nn: 0.202858, good_ratio: 0.930205, good_clusters: 0.957014, good_ratio_and_clusters: 0.970849
[       OK ] MATCHING.Scale110 (720 ms)
[ RUN      ] MATCHING.Scale130
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 519/838
estimateHomographyRANSAC : support: 837/838
estimateHomographyRANSAC : best support: 837/838
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.142842, time_cv: 0.135387, time_bruteforce: 0, good_nn: 0.217913, good_ratio: 0.949267, good_clusters: 0.991935, good_ratio_and_clusters: 0.98926
[       OK ] MATCHING.Scale130 (980 ms)
[ RUN      ] MATCHING.Scale150
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 655/790
estimateHomographyRANSAC : support: 787/790
estimateHomographyRANSAC : best support: 787/790
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.216238, time_cv: 0.191573, time_bruteforce: 0, good_nn: 0.206175, good_ratio: 0.945978, good_clusters: 0.985138, good_ratio_and_clusters: 0.98481
[       OK ] MATCHING.Scale150 (1301 ms)
[ RUN      ] MATCHING.Scale175
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 418/769
estimateHomographyRANSAC : support: 617/769
estimateHomographyRANSAC : support: 764/769
estimateHomographyRANSAC : best support: 764/769
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.24921, time_cv: 0.260772, time_bruteforce: 0, good_nn: 0.189079, good_ratio: 0.892857, good_clusters: 0.932755, good_ratio_and_clusters: 0.93238
[       OK ] MATCHING.Scale175 (1653 ms)
[ RUN      ] MATCHING.Scale200
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 852/856
estimateHomographyRANSAC : best support: 852/856
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.278781, time_cv: 0.27757, time_bruteforce: 0, good_nn: 0.211789, good_ratio: 0.917226, good_clusters: 0.93186, good_ratio_and_clusters: 0.946262
[       OK ] MATCHING.Scale200 (1986 ms)
[ RUN      ] MATCHING.Rotate10Scale90
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 506/649
estimateHomographyRANSAC : support: 640/649
estimateHomographyRANSAC : support: 649/649
estimateHomographyRANSAC : best support: 649/649
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.079509, time_cv: 0.07763, time_bruteforce: 0, good_nn: 0.159224, good_ratio: 0.873913, good_clusters: 0.884298, good_ratio_and_clusters: 0.922958
[       OK ] MATCHING.Rotate10Scale90 (623 ms)
[ RUN      ] MATCHING.Rotate30Scale75
testing sift detector/descriptor...
flann matching...
cv flann matching...
filtering matches by ratio test...
filtering matches by clusters...
filtering matches by ratio & clusters
estimating homography...
estimateHomographyRANSAC : support: 128/440
estimateHomographyRANSAC : support: 373/440
estimateHomographyRANSAC : support: 404/440
estimateHomographyRANSAC : support: 437/440
estimateHomographyRANSAC : best support: 437/440
evaluating homography...
nn_score: 0, nn2_score: 0, nn_score_cv: 0, nn2_score_cv: 0, time_my: 0.08805, time_cv: 0.066352, time_bruteforce: 0, good_nn: 0.105129, good_ratio: 0.841542, good_clusters: 0.776471, good_ratio_and_clusters: 0.888636
[       OK ] MATCHING.Rotate30Scale75 (537 ms)
[----------] 18 tests from MATCHING (17598 ms total)

[----------] 2 tests from STITCHING
[ RUN      ] STITCHING.SimplePanorama
estimateHomographyRANSAC : support: 998/1002
estimateHomographyRANSAC : best support: 998/1002
bbox: [1279.45, 640.531], [0, 0]
[       OK ] STITCHING.SimplePanorama (585 ms)
[ RUN      ] STITCHING.Orthophoto
estimateHomographyRANSAC : support: 57/1442
estimateHomographyRANSAC : support: 97/1442
estimateHomographyRANSAC : support: 463/1442
estimateHomographyRANSAC : best support: 463/1442
estimateHomographyRANSAC : support: 26/1133
estimateHomographyRANSAC : support: 37/1133
estimateHomographyRANSAC : support: 291/1133
estimateHomographyRANSAC : best support: 291/1133
estimateHomographyRANSAC : support: 220/2192
estimateHomographyRANSAC : support: 290/2192
estimateHomographyRANSAC : best support: 290/2192
estimateHomographyRANSAC : support: 11/1317
estimateHomographyRANSAC : support: 470/1317
estimateHomographyRANSAC : best support: 470/1317
bbox: [1236.2, 1739.08], [-212.824, -341.357]
estimateHomographyRANSAC : support: 64/1195
estimateHomographyRANSAC : support: 307/1195
estimateHomographyRANSAC : best support: 307/1195
estimateHomographyRANSAC : support: 281/1479
estimateHomographyRANSAC : support: 366/1479
estimateHomographyRANSAC : best support: 366/1479
estimateHomographyRANSAC : support: 171/2210
estimateHomographyRANSAC : support: 368/2210
estimateHomographyRANSAC : best support: 368/2210
estimateHomographyRANSAC : support: 250/1311
estimateHomographyRANSAC : best support: 250/1311
bbox: [1162.79, 864], [-391.874, -915.516]
n stable ortho kpts: : 20472
[       OK ] STITCHING.Orthophoto (15170 ms)
[----------] 2 tests from STITCHING (15755 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (33353 ms total)
[  PASSED  ] 19 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] MATCHING.Scale50

 1 FAILED TEST

Process finished with exit code 1
</p></details>