### PR TITLE
Task04 Денис Коротченко СПбГУ

### DIFF
--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -36,7 +36,10 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double y = point[1] / point[2];
 
     // TODO 11: добавьте учет радиальных искажений (k1_, k2_) (после деления на Z, но до умножения на f)
-
+    double r = x * x + y * y;
+    double d = k1_ * r + k2_ * r * r;
+    x += d;
+    y += d;
 
     x *= f_;
     y *= f_;
@@ -56,6 +59,10 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     y /= f_;
 
     // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    double r = x * x + y * y;
+    double d = k1_ * r + k2_ * r * r;
+    x -= d;
+    y -= d;
 
     return cv::Vec3d(x, y, 1.0);
 }

--- a/tests/test_ceres_solver.cpp
+++ b/tests/test_ceres_solver.cpp
@@ -67,6 +67,7 @@ TEST (CeresSolver, HelloWorld1) {
     std::cout << "f(x):  " << initial_residual << " -> " << final_residual << std::endl;
     std::cout << "f'(x): " << initial_jacobian << " -> " << final_jacobian << std::endl;
     // TODO 1: почему результирующая производная не ноль? мы ведь должны были сойтись в минимуме функции 0.5*(10-x)^2
+    // да, но f(x) = 10 - x, соответственно f'(x) = -1
 
     ASSERT_NEAR(cur_x, 10.0, 1e-6);
 }
@@ -132,7 +133,7 @@ public:
         // Поэтому например для вычисления квадрата - можно просто перемножить T-переменные, а для вычисления произвольной степени - ceres::pow(x, y)
         T dx = queryPoint[0] - center[0];
         T dy = queryPoint[1] - center[1];
-        residual[0] = a*dx*dx + b*dy*dy - center[2];
+        residual[0] = a*dx*dx + b*dy*dy + center[2] - queryPoint[2];
         return true;
     }
 protected:
@@ -158,10 +159,10 @@ TEST (CeresSolver, HelloWorld2) {
     ceres::CostFunction* paraboloid_cost_function = new ceres::AutoDiffCostFunction<ResidualToParaboloid, 1, 3>
             (new ResidualToParaboloid(paraboloid_center, paraboloid_a, paraboloid_b));
 
-    return; // TODO 2 удалите эту строку, затем
+    // TODO 2 удалите эту строку, затем
     // нарисуйте систему координат на бумажке чтобы найти координаты пересечения прямой и параболоида (параболоид и прямые - простые, поэтому пересечь их довольно просто)
     // и подставьте найденные координаты эталонного ответа в массив:
-    const double expected_point_solution[3] = {-1000.0, -1000.0, -1000.0};
+    const double expected_point_solution[3] = {10.0, 5.0, 200.0};
     {
         // Проверим что невязка эталонного решения нулевая для обоих функций невязки
         const double* params[1];
@@ -225,8 +226,10 @@ TEST (CeresSolver, HelloWorld2) {
     }
 
     for (int d = 0; d < 3; ++d) {
-//        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
+        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
         // TODO 3: раскомментируйте^, почему он находит не то что ожидалось?
+        // Потому что была ошибка в части расстояния до параболоида
+
         // либо мы набагали в коде, либо в аналитическом поиске правильного ответа на бумажке (проверьте вычисления на бумажке)
         // если бага в коде, то первые подозреваемые - две функции невязки (только там есть содержательный код)
         // заметьте что у найденного ответа ошибка только по одной из осей
@@ -260,7 +263,7 @@ public:
         // Блок параметров - line=[a, b, c] - задает прямую вида ax+by+c=0
         // TODO 5 посчитайте единственную невязку - расстояние от нашей точки-замера до текущего состояния прямой (для извлечения корня, помня про T=Jet, нужно использовать ceres::sqrt):
         // обратите внимание что расстояние лучше оставить знаковым, т.к. тогда эта невязка будет хорошо дифференцироваться при расстоянии около нуля
-//        residual[0] = ;
+        residual[0] = (line[0] * samplePoint[0] + line[1] * samplePoint[1] + line[2]) / ceres::sqrt(line[0] * line[0] + line[1] * line[1]);
         return true;
     }
 protected:
@@ -348,7 +351,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
                 1, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки, у нас это просто расстояние до прямой)
                 3> // число параметров в каждом блоке параметров, у нас один блок параметров (искомая прямая) из трех ее параметров - a, b, c
                 (new PointObservationError(points[i]));
-        return; // TODO 6 удалите этот return сразу после выполнения TODO 5
+        // TODO 6 удалите этот return сразу после выполнения TODO 5
 
         ceres::LossFunction* loss;
         if (use_huber) {
@@ -375,7 +378,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
         threshold *= 10.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
     }
     for (int d = 0; d < 3; ++d) {
-//        ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
+        ASSERT_NEAR(line_params[d] / (line_params[2] != 0.0 ? line_params[2] : 1.0), ideal_line[d] / (ideal_line[2] != 0.0 ? ideal_line[2] : 1.0), threshold);
         // TODO 7 расскоментируйте сверку найденной прямой и эталонной
         // почему они расходятся? как это можно решить? придумайте хотя бы два способа:
         // - пост-обработкой - как-то поправив параметры прямой перед сверкой (при этом не меняя ее положение в пространстве)
@@ -386,15 +389,18 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
     // Оцениваем качество идеальной прямой
     double inliers_fraction, mse;
     evaluateLine(points, ideal_line, sigma, inliers_fraction, mse);
-//    ASSERT_GT(inliers_fraction, 0.99); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
-//    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    ASSERT_GT(inliers_fraction, 0.99 * (1.0 - outliers_fraction)); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
+    // В данных есть выбросы, через которые не нужно фитить прямую
+    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    // Падает на FitLineNoiseAndOutliers и FitLineNoiseAndOutliersWithHuberLoss
+    // Из-за того, что мы выше решили, что знак у расстояния оставляем, то и при сравнении в evaluateLine надо сделать модуль
 
     // Оцениваем качество найденной прямой
     evaluateLine(points, line_params, sigma, inliers_fraction, mse);
     if (outliers_fraction == 0 || use_huber) {
         // TODO 10 раскоментируйте обе проверки, почему они падают? в каких тестах? поправьте (в т.ч. подобно тому как было с ослаблением порога выше)
-//        ASSERT_GT(inliers_fraction, 0.99);
-//        ASSERT_LT(mse, 1.1 * sigma * sigma);
+        ASSERT_GT(inliers_fraction, 0.99 * (1.0 - outliers_fraction));
+        ASSERT_LT(mse, 1.1 * sigma * sigma);
     }
 }
 
@@ -405,7 +411,7 @@ void evaluateLine(const std::vector<double_2> &points, const double* line,
     mse_inliers_distance = 0.0; // mean square error
     for (size_t i = 0; i < n; ++i) {
         double dist = calcDistanceToLine2D(points[i][0], points[i][1], line);
-        if (dist <= 3 * sigma) {
+        if (abs(dist) <= 3 * sigma) {
             ++inliers;
             mse_inliers_distance += dist * dist;
         }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -40,17 +40,17 @@
 // Datasets:
 
 // достаточно чтобы у вас работало на этом датасете, тестирование на Travis CI тоже ведется на нем
-//#define DATASET_DIR                  "saharov32"
-//#define DATASET_DOWNSCALE            1 // картинки уже уменьшены в 4 раза (оригинальные вы можете скачать по ссылке из saharov32/LINK.txt)
-//#define DATASET_F                    (1585.5 / DATASET_DOWNSCALE)
+#define DATASET_DIR                  "saharov32"
+#define DATASET_DOWNSCALE            1 // картинки уже уменьшены в 4 раза (оригинальные вы можете скачать по ссылке из saharov32/LINK.txt)
+#define DATASET_F                    (1585.5 / DATASET_DOWNSCALE)
 
 // но если любопытно - для экспериментов предлагаются еще дополнительные датасеты
 // скачайте их фотографии в папку data/src/datasets/DATASETNAME/ по ссылке из файла LINK.txt в папке датасета:
 
 // saharov32 и herzjesu25 - приятные датасеты, вероятно их оба получится выравнять целиком
-#define DATASET_DIR                  "herzjesu25"
-#define DATASET_DOWNSCALE            2 // для ускорения SIFT
-#define DATASET_F                    (2761.5 / DATASET_DOWNSCALE) // see herzjesu25/K.txt
+//#define DATASET_DIR                  "herzjesu25"
+//#define DATASET_DOWNSCALE            2 // для ускорения SIFT
+//#define DATASET_F                    (2761.5 / DATASET_DOWNSCALE) // see herzjesu25/K.txt
 // TODO почему фокальная длина меняется от того что мы уменьшаем картинку? почему именно в такой пропорции? может надо домножать? или делить на downscale^2 ?
 
 // но temple47 - не вышло, я не разобрался в чем с ним проблема, может быть слишком мало точек, может критерии фильтрации выкидышей для него слишком строги


### PR DESCRIPTION
1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

В случае, если мы задаём прямую в виде ax+by+c=0, то домножение на константу прямую не изменит, таким образом у нас возникает неоднозначность в задании прямой. Пост-обработка - привести к виду, когда младший ненулевой коэффициент = 1 (деление на соотетствующий коэффициент). В формулировке можно сказать, что мы задаём прямую двумя коэффициентами (kx+b), тогда такой неоднозначности не будет.

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

Проверка на корректность - применить прямое образование, а затем обратное, проверить после этого, что данные изменились в пределах погрешности.
С точки зрения изменения лога runBA(), должно примерно сохраниться число инлайеров, то есть лог должен быть примерно похожий.

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

Удалось выравнить 32 и 25 картинок соответственно

![image](https://user-images.githubusercontent.com/23313805/236023782-6a537698-fdaa-41d7-9413-ad389dd18732.png)

![image](https://user-images.githubusercontent.com/23313805/236023771-04daf9ab-74ba-42ec-b19a-2e805f3d9d72.png)


4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Нет, поскольку в unproject мы смотрим на искажённую точку, у которой может быть другой радиус.

5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

Что такое процекция? Это последовательное применение поворота, скэйла, умножение на f и сдвиг. Ну получается, что если мы уменьшаем картинку в downscale раз, то этого можно добиться умножая не на f, а на f/downscale.

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Да: сдвиг на константу не изменит невязки, и Loss тоже не поменяется.

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

Для этого достаточно зафиксировать первую камеру. Но после этого у нас всё будет хорошо, кроме того, что может меняться масштаб. Чтобы от этого тоже избавиться, можно зафиксировать вторую камеру.