### PR TITLE
Task04 Владимир Рачкин МКН

### DIFF
--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -36,7 +36,9 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double y = point[1] / point[2];
 
     // TODO 11: добавьте учет радиальных искажений (k1_, k2_) (после деления на Z, но до умножения на f)
-
+    double r2 = x * x + y * y;
+    x *= 1 + k1_ * r2 + k2_ * r2 * r2;
+    y *= 1 + k1_ * r2 + k2_ * r2 * r2;
 
     x *= f_;
     y *= f_;
@@ -56,6 +58,10 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     y /= f_;
 
     // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    // в project r2 считался до искажения, а в unproject - после
+    double r2 = x * x + y * y;
+    x -= k1_ * r2 + k2_ * r2 * r2;
+    y -= k1_ * r2 + k2_ * r2 * r2;
 
     return cv::Vec3d(x, y, 1.0);
 }

--- a/tests/test_ceres_solver.cpp
+++ b/tests/test_ceres_solver.cpp
@@ -67,6 +67,7 @@ TEST (CeresSolver, HelloWorld1) {
     std::cout << "f(x):  " << initial_residual << " -> " << final_residual << std::endl;
     std::cout << "f'(x): " << initial_jacobian << " -> " << final_jacobian << std::endl;
     // TODO 1: почему результирующая производная не ноль? мы ведь должны были сойтись в минимуме функции 0.5*(10-x)^2
+    // У нас f(x) = 10 - x, f'(x) = -1. А такая f - cost_function, loss_function(x) = cost_function(x)^2
 
     ASSERT_NEAR(cur_x, 10.0, 1e-6);
 }
@@ -132,7 +133,7 @@ public:
         // Поэтому например для вычисления квадрата - можно просто перемножить T-переменные, а для вычисления произвольной степени - ceres::pow(x, y)
         T dx = queryPoint[0] - center[0];
         T dy = queryPoint[1] - center[1];
-        residual[0] = a*dx*dx + b*dy*dy - center[2];
+        residual[0] = a*dx*dx + b*dy*dy + center[2] - queryPoint[2];
         return true;
     }
 protected:
@@ -158,10 +159,10 @@ TEST (CeresSolver, HelloWorld2) {
     ceres::CostFunction* paraboloid_cost_function = new ceres::AutoDiffCostFunction<ResidualToParaboloid, 1, 3>
             (new ResidualToParaboloid(paraboloid_center, paraboloid_a, paraboloid_b));
 
-    return; // TODO 2 удалите эту строку, затем
+    // TODO 2 удалите эту строку, затем
     // нарисуйте систему координат на бумажке чтобы найти координаты пересечения прямой и параболоида (параболоид и прямые - простые, поэтому пересечь их довольно просто)
     // и подставьте найденные координаты эталонного ответа в массив:
-    const double expected_point_solution[3] = {-1000.0, -1000.0, -1000.0};
+    const double expected_point_solution[3] = {10.0, 5.0, 200.0};
     {
         // Проверим что невязка эталонного решения нулевая для обоих функций невязки
         const double* params[1];
@@ -225,7 +226,7 @@ TEST (CeresSolver, HelloWorld2) {
     }
 
     for (int d = 0; d < 3; ++d) {
-//        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
+        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
         // TODO 3: раскомментируйте^, почему он находит не то что ожидалось?
         // либо мы набагали в коде, либо в аналитическом поиске правильного ответа на бумажке (проверьте вычисления на бумажке)
         // если бага в коде, то первые подозреваемые - две функции невязки (только там есть содержательный код)
@@ -234,6 +235,8 @@ TEST (CeresSolver, HelloWorld2) {
         // отладьте те функции невязки которые по-хорошему не должны соглашаться на такой ответ - поставьте просто точку остановки чуть выше, там где мы проверяли
         // что невязка найденного решения - нулевая, и найдите где вдруг ваше ожидание большой невязки для этого ответа сталкивается с суровой реальностью баги в коде
         // которая приводит к нулевой невязке
+        //
+        // Набагали в расстоянии до параболоида по оси Z
     }
 
     // TODO 4: если любопытно и хватит времени - можете попросить ceres-solver посчитать якобианы в некоторых точках подобно тому как это делалось в конце теста HelloWorld1
@@ -260,7 +263,7 @@ public:
         // Блок параметров - line=[a, b, c] - задает прямую вида ax+by+c=0
         // TODO 5 посчитайте единственную невязку - расстояние от нашей точки-замера до текущего состояния прямой (для извлечения корня, помня про T=Jet, нужно использовать ceres::sqrt):
         // обратите внимание что расстояние лучше оставить знаковым, т.к. тогда эта невязка будет хорошо дифференцироваться при расстоянии около нуля
-//        residual[0] = ;
+        residual[0] = abs(line[0] * samplePoint[0] + line[1] * samplePoint[1] + line[2]) / ceres::sqrt(line[0] * line[0] + line[1] * line[1]);
         return true;
     }
 protected:
@@ -348,7 +351,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
                 1, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки, у нас это просто расстояние до прямой)
                 3> // число параметров в каждом блоке параметров, у нас один блок параметров (искомая прямая) из трех ее параметров - a, b, c
                 (new PointObservationError(points[i]));
-        return; // TODO 6 удалите этот return сразу после выполнения TODO 5
+        // TODO 6 удалите этот return сразу после выполнения TODO 5
 
         ceres::LossFunction* loss;
         if (use_huber) {
@@ -375,26 +378,30 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
         threshold *= 10.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
     }
     for (int d = 0; d < 3; ++d) {
-//        ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
+        ASSERT_NEAR(line_params[d] / line_params[2], ideal_line[d] / ideal_line[2], threshold);
         // TODO 7 расскоментируйте сверку найденной прямой и эталонной
         // почему они расходятся? как это можно решить? придумайте хотя бы два способа:
         // - пост-обработкой - как-то поправив параметры прямой перед сверкой (при этом не меняя ее положение в пространстве)
         // - формулировкой задачи - можно сформулировать для ceres-solver задчау так чтобы избавиться от неоднозначности убрав степень свободы, т.е. описав прямую как-то иначе, как?
         // TODO 7 поправьте тест так или иначе (хотя бы пост-процессингом)
+        //
+        // В решении есть свобода по масштабу параметров, её легко убрать
     }
 
     // Оцениваем качество идеальной прямой
     double inliers_fraction, mse;
     evaluateLine(points, ideal_line, sigma, inliers_fraction, mse);
-//    ASSERT_GT(inliers_fraction, 0.99); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
-//    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    ASSERT_GT(inliers_fraction, 0.99 * (1 - outliers_fraction)); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
+    // Падает когда много выбросов
+    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    // В evaluateLine была ошибка, много выбросов считалось инлаерами
 
     // Оцениваем качество найденной прямой
     evaluateLine(points, line_params, sigma, inliers_fraction, mse);
     if (outliers_fraction == 0 || use_huber) {
         // TODO 10 раскоментируйте обе проверки, почему они падают? в каких тестах? поправьте (в т.ч. подобно тому как было с ослаблением порога выше)
-//        ASSERT_GT(inliers_fraction, 0.99);
-//        ASSERT_LT(mse, 1.1 * sigma * sigma);
+        ASSERT_GT(inliers_fraction, 0.99 * (1 - outliers_fraction));
+        ASSERT_LT(mse, 1.1 * sigma * sigma);
     }
 }
 
@@ -405,7 +412,7 @@ void evaluateLine(const std::vector<double_2> &points, const double* line,
     mse_inliers_distance = 0.0; // mean square error
     for (size_t i = 0; i < n; ++i) {
         double dist = calcDistanceToLine2D(points[i][0], points[i][1], line);
-        if (dist <= 3 * sigma) {
+        if (abs(dist) <= 3 * sigma) {
             ++inliers;
             mse_inliers_distance += dist * dist;
         }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -22,7 +22,7 @@
 #include <ceres/ceres.h>
 
 // TODO включите Bundle Adjustment (но из любопытства посмотрите как ведет себя реконструкция без BA например для saharov32 без BA)
-#define ENABLE_BA                             0
+#define ENABLE_BA                             1
 
 // TODO когда заработает при малом количестве фотографий - увеличьте это ограничение до 100 чтобы попробовать обработать все фотографии (если же успешно будут отрабаывать только N фотографий - отправьте PR выставив здесь это N)
 #define NIMGS_LIMIT                           10 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
@@ -385,24 +385,53 @@ public:
         // TODO реализуйте функцию проекции, все нужно делать в типе T чтобы ceres-solver мог под него подставить как Jet (очень рекомендую посмотреть Jet.h - как класная статья из википедии!), так и double
 
         // translation[3] - сдвиг в локальную систему координат камеры
+        const T* translation = camera_extrinsics;
 
         // rotation[3] - angle-axis rotation, поворачиваем точку point->p (чтобы перейти в локальную систему координат камеры)
+        const T* rotation = camera_extrinsics + 3;
         // подробнее см. https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation
         // (P.S. у камеры всмысле вращения три степени свободы)
+        T transform[9];
+        ceres::AngleAxisToRotationMatrix(rotation, transform);
 
         // Проецируем точку на фокальную плоскость матрицы (т.е. плоскость Z=фокальная длина)
+        T point[3];
+        for (int i = 0; i < 3; i++) {
+            point[i] = T(0);
+            for (int j = 0; j < 3; j++) {
+                point[i] += transform[3 * j + i] * (point_global[j] - translation[j]);
+            }
+        }
+
+        T x = point[0] / point[2];
+        T y = point[1] / point[2];
 
 #if ENABLE_INSTRINSICS_K1_K2
         // k1, k2 - коэффициенты радиального искажения (radial distortion)
+        T k1 = camera_intrinsics[0];
+        T k2 = camera_intrinsics[1];
+        T r2 = x * x + y * y;
+        T add = k1 * r2 + k2 * r2 * r2;
+        x += add;
+        y += add;
 #endif
 
         // Домножаем на f, тем самым переводя в пиксели
+        T f = camera_intrinsics[2];
+        x *= f;
+        y *= f;
 
         // Из координат когда точка (0, 0) - центр оптической оси
         // Переходим в координаты когда точка (0, 0) - левый верхний угол картинки
         // cx, cy - координаты центра оптической оси (обычно это центр картинки, но часто он чуть смещен)
+        T cx = camera_intrinsics[3];
+        T cy = camera_intrinsics[4];
+        x += cx;
+        y += cy;
 
         // Теперь по спроецированным координатам не забудьте посчитать невязку репроекции
+        residuals[0] = x - observed_x;
+        residuals[1] = y - observed_y;
 
         return true;
         // TODO сверьте эту функцию с вашей реализацией проекции в src/phg/core/calibration.cpp (они должны совпадать)
@@ -436,7 +465,7 @@ void runBA(std::vector<vector3d> &tie_points,
 
     // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy}
     // TODO: преобразуйте calib в блок параметров камеры (ее внутренних характеристик) для оптимизации в BA
-    double camera_intrinsics[5];
+    double camera_intrinsics[5] = {calib.k1_, calib.k2_, calib.f_, calib.cx_ + 0.5 * calib.width_, calib.cy_ + 0.5 * calib.height_};
     std::cout << "Before BA ";
     printCamera(camera_intrinsics);
 
@@ -576,7 +605,11 @@ void runBA(std::vector<vector3d> &tie_points,
     std::cout << "After BA ";
     printCamera(camera_intrinsics);
     // TODO преобразуйте параметры камеры в обратную сторону, чтобы последующая резекция учла актуальное представление о пространстве:
-    // calib.* = camera_intrinsics[*];
+    calib.k1_ = camera_intrinsics[0];
+    calib.k2_ = camera_intrinsics[1];
+    calib.f_  = camera_intrinsics[2];
+    calib.cx_ = camera_intrinsics[3] - 0.5 * calib.width_;
+    calib.cy_ = camera_intrinsics[4] - 0.5 * calib.height_;
 
     ASSERT_NEAR(calib.f_ , DATASET_F, 0.2 * DATASET_F);
     ASSERT_NEAR(calib.cx_, 0.0, 0.3 * calib.width());
@@ -650,7 +683,8 @@ void runBA(std::vector<vector3d> &tie_points,
 
             if (ENABLE_OUTLIERS_FILTRATION_COLINEAR && ENABLE_BA) {
                 // TODO выполните проверку случая когда два луча почти параллельны, чтобы не было странных точек улетающих на бесконечность (например чтобы угол был хотя бы 2.5 градуса)
-                // should_be_disabled = true;
+//                 should_be_disabled = true;
+
             }
 
             {


### PR DESCRIPTION
1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

Это проблема связана со свободой по маштабированию

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

Нужно применить прямое, затем обратное преобразование, должен получиться одинаковый результат. Если runBA вызвать 2 раза подряд, то процента инлаеров будет такой же, если применить только один раз. Это и есть идемпотентность.

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

Слишком долго считалось даже до 15 в saharov32 и выровнялось

![img](https://i.imgur.com/0JvefGD.png)

Слишком долго считалось даже до 15 в herzjesu25 и выровнялось

![img](https://i.imgur.com/P1QICzl.png)


4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Из-за радиальных искажений

5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

Как работает проекция? Сначала перемещаем, потом вращаем. После 3д переводим в 2д поделив на Z. (Поле этого добовляем радиальные искажения.) После домножаем на фоскальную длину ($f$) - переводим в пиксели. Переносим центр оптической оси  прибавляя $cx$, $cy$.

Если мы даунскейлим, то нужно после перевода в пиксели поделить на downscale. Это деление можно совместить с домножением на фокусное растояние ($f$), просто домножая на f / downscale.

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Да, это можно сделать, это никак не повлияет на loss

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

Фиксируем положение двух первых камер


<details><summary>Travis CI</summary><p>

<pre>
Run ./build/test_ceres_solver
Running main() from /home/runner/work/PhotogrammetryTasks2023/PhotogrammetryTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from CeresSolver
[ RUN      ] CeresSolver.HelloWorld1
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.250000e+01    0.00e+00    5.00e+00   0.00e+00   0.00e+00  1.00e+04        0    1.50e-05    9.30e-05
   1  1.249750e-07    1.25e+01    5.00e-04   5.00e+00   1.00e+00  3.00e+04        1    3.19e-04    2.54e-02
   2  1.388518e-16    1.25e-07    1.67e-08   5.00e-04   1.00e+00  9.00e+04        1    6.91e-06    2.54e-02
Ceres Solver Report: Iterations: 3, Initial cost: 1.250000e+01, Final cost: 1.388518e-16, Termination: CONVERGENCE
x:     5 -> 10
f(x):  5 -> 1.66644e-08
f'(x): -1 -> -1
[       OK ] CeresSolver.HelloWorld1 (26 ms)
[ RUN      ] CeresSolver.HelloWorld2
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  6.131250e+04    0.00e+00    1.40e+04   0.00e+00   0.00e+00  1.00e+04        0    4.99e-04    5.39e-04
   1  3.127313e+04    3.00e+04    7.82e+03   4.47e+01   4.90e-01  1.00e+04        1    1.22e-05    5.86e-04
   2  5.685772e+02    3.07e+04    7.75e+02   1.01e+02   9.82e-01  3.00e+04        1    5.96e-06    6.30e-04
   3  1.137952e+02    4.55e+02    2.90e+02   2.55e+01   8.00e-01  3.83e+04        1    3.10e-06    6.40e-04
   4  1.931689e+00    1.12e+02    3.82e+01   1.97e+01   9.83e-01  1.15e+05        1    3.10e-06    6.49e-04
   5  6.620880e-01    1.27e+00    2.23e+01   4.56e+00   6.57e-01  1.18e+05        1    2.86e-06    6.57e-04
   6  1.715778e-02    6.45e-01    2.45e+00   4.10e+00   9.74e-01  3.55e+05        1    3.10e-06    6.65e-04
   7  2.040825e-03    1.51e-02    8.69e-01   8.05e-01   8.81e-01  6.37e+05        1    2.86e-06    6.73e-04
   8  3.955432e-04    1.65e-03    1.23e-01   8.19e-01   8.06e-01  8.28e+05        1    3.10e-06    6.80e-04
   9  4.204592e-05    3.53e-04    3.09e-02   1.49e-01   8.94e-01  1.62e+06        1    5.01e-06    7.27e-04
  10  1.366023e-05    2.84e-05    5.85e-03   1.57e-01   6.75e-01  1.69e+06        1    2.86e-06    7.35e-04
  11  1.455687e-06    1.22e-05    7.13e-04   2.79e-02   8.93e-01  3.29e+06        1    3.10e-06    7.42e-04
  12  4.821191e-07    9.74e-07    7.85e-04   2.95e-02   6.69e-01  3.43e+06        1    5.01e-06    7.85e-04
  13  5.128650e-08    4.31e-07    2.64e-04   5.24e-03   8.94e-01  6.69e+06        1    4.05e-06    7.94e-04
  14  1.696961e-08    3.43e-08    1.71e-04   5.54e-03   6.69e-01  6.96e+06        1    2.86e-06    8.01e-04
  15  1.803689e-09    1.52e-08    5.60e-05   9.82e-04   8.94e-01  1.36e+07        1    4.05e-06    8.42e-04
  16  5.966373e-10    1.21e-09    3.29e-05   1.04e-03   6.69e-01  1.41e+07        1    3.10e-06    8.49e-04
  17  6.339313e-11    5.33e-10    1.07e-05   1.84e-04   8.94e-01  2.77e+07        1    4.05e-06    8.98e-04
  18  2.096924e-11    4.24e-11    6.19e-06   1.95e-04   6.69e-01  2.88e+07        1    3.10e-06    9.07e-04
  19  2.227619e-12    1.87e-11    2.02e-06   3.45e-05   8.94e-01  5.62e+07        1    2.86e-06    9.14e-04
  20  7.368654e-13    1.49e-12    1.16e-06   3.65e-05   6.69e-01  5.85e+07        1    5.01e-06    9.56e-04
  21  7.827280e-14    6.59e-13    3.79e-07   6.47e-06   8.94e-01  1.14e+08        1    4.05e-06    9.65e-04
  22  2.589188e-14    5.24e-14    2.18e-07   6.84e-06   6.69e-01  1.19e+08        1    3.10e-06    9.73e-04
Ceres Solver Report: Iterations: 23, Initial cost: 6.131250e+04, Final cost: 2.589188e-14, Termination: CONVERGENCE
Found intersection point: (10, 5, 200)
[       OK ] CeresSolver.HelloWorld2 (1 ms)
[ RUN      ] CeresSolver.FitLineNoise
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  4.506761e+07    0.00e+00    1.61e+08   0.00e+00   0.00e+00  1.00e+04        0    1.99e-04    2.86e-04
   1  4.658321e+02    4.51e+07    1.33e+04   1.00e+02   1.00e+00  3.00e+04        1    2.81e-04    5.83e-04
   2  4.654480e+02    3.84e-01    1.61e-01   5.13e-03   1.00e+00  9.00e+04        1    2.50e-04    8.59e-04
Ceres Solver Report: Iterations: 3, Initial cost: 4.506761e+07, Final cost: 4.654480e+02, Termination: CONVERGENCE
Found line: (a=-0.500026, b=0.999948, c=-100.052)
[       OK ] CeresSolver.FitLineNoise (4 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliers
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.201187e+08    0.00e+00    1.37e+08   0.00e+00   0.00e+00  1.00e+04        0    1.71e-04    2.30e-04
   1  7.448902e+07    4.56e+07    5.33e+07   8.51e+01   1.41e+00  3.00e+04        1    2.42e-04    4.91e-04
   2  6.772855e+07    6.76e+06    1.27e+07   1.55e+01   1.41e+00  9.00e+04        1    2.36e-04    7.53e-04
   3  6.739936e+07    3.29e+05    3.88e+06   2.30e+00   1.33e+00  2.70e+05        1    2.39e-04    1.12e-03
   4  6.736832e+07    3.10e+04    1.21e+06   6.64e-01   1.32e+00  8.10e+05        1    3.36e-04    1.47e-03
   5  6.736525e+07    3.07e+03    3.83e+05   2.05e-01   1.32e+00  2.43e+06        1    3.23e-04    1.80e-03
   6  6.736495e+07    3.06e+02    1.21e+05   6.45e-02   1.32e+00  7.29e+06        1    3.21e-04    2.13e-03
Ceres Solver Report: Iterations: 7, Initial cost: 1.201187e+08, Final cost: 6.736495e+07, Termination: CONVERGENCE
Found line: (a=-0.549481, b=0.767491, c=-66.3904)
[       OK ] CeresSolver.FitLineNoiseAndOutliers (3 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.096949e+06    0.00e+00    1.13e+06   0.00e+00   0.00e+00  1.00e+04        0    1.72e-04    2.27e-04
   1  5.506564e+05    5.46e+05    1.19e+06   8.24e+01   2.14e+00  3.00e+04        1    3.73e-04    6.17e-04
   2  4.578101e+05    9.28e+04    9.63e+05   6.74e+00   1.74e+00  9.00e+04        1    2.99e-04    9.27e-04
   3  4.504957e+05    7.31e+03    2.85e+05   3.04e-01   1.65e+00  2.70e+05        1    2.83e-04    1.22e-03
   4  4.503340e+05    1.62e+02    4.22e+03   1.43e-02   1.02e+00  8.10e+05        1    2.84e-04    1.51e-03
Ceres Solver Report: Iterations: 5, Initial cost: 1.096949e+06, Final cost: 4.503340e+05, Termination: CONVERGENCE
Found line: (a=-0.445255, b=0.889226, c=-88.902)
[       OK ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss (3 ms)
[----------] 5 tests from CeresSolver (37 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (37 ms total)
[  PASSED  ] 5 tests.


Run ./build/test_sfm_ba
Running main() from /home/runner/work/PhotogrammetryTasks2023/PhotogrammetryTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SFM
[ RUN      ] SFM.ReconstructNViews
32 images
detecting points...
matching points...
0% - Cameras 0-1 (IMG_3023.JPG-IMG_3024.JPG): 1159 matches
1% - Cameras 0-2 (IMG_3023.JPG-IMG_3025.JPG): 442 matches
2% - Cameras 0-3 (IMG_3023.JPG-IMG_3026.JPG): 148 matches
3% - Cameras 0-4 (IMG_3023.JPG-IMG_3027.JPG): 53 matches
4% - Cameras 8-3 (IMG_3031.JPG-IMG_3026.JPG): 21 matches
5% - Cameras 8-4 (IMG_3031.JPG-IMG_3027.JPG): 182 matches
6% - Cameras 8-5 (IMG_3031.JPG-IMG_3028.JPG): 361 matches
7% - Cameras 8-6 (IMG_3031.JPG-IMG_3029.JPG): 876 matches
8% - Cameras 8-7 (IMG_3031.JPG-IMG_3030.JPG): 1254 matches
9% - Cameras 8-9 (IMG_3031.JPG-IMG_3032.JPG): 1556 matches
10% - Cameras 8-10 (IMG_3031.JPG-IMG_3033.JPG): 661 matches
10% - Cameras 0-11 (IMG_3023.JPG-IMG_3034.JPG): 19 matches
10% - Cameras 8-11 (IMG_3031.JPG-IMG_3034.JPG): 191 matches
14% - Cameras 1-0 (IMG_3024.JPG-IMG_3023.JPG): 1015 matches
15% - Cameras 1-2 (IMG_3024.JPG-IMG_3025.JPG): 1147 matches
16% - Cameras 1-3 (IMG_3024.JPG-IMG_3026.JPG): 352 matches
17% - Cameras 1-4 (IMG_3024.JPG-IMG_3027.JPG): 145 matches
18% - Cameras 9-4 (IMG_3032.JPG-IMG_3027.JPG): 91 matches
19% - Cameras 9-5 (IMG_3032.JPG-IMG_3028.JPG): 278 matches
20% - Cameras 9-6 (IMG_3032.JPG-IMG_3029.JPG): 453 matches
20% - Cameras 9-7 (IMG_3032.JPG-IMG_3030.JPG): 739 matches
22% - Cameras 9-8 (IMG_3032.JPG-IMG_3031.JPG): 1549 matches
23% - Cameras 9-10 (IMG_3032.JPG-IMG_3033.JPG): 1359 matches
24% - Cameras 9-11 (IMG_3032.JPG-IMG_3034.JPG): 440 matches
25% - Cameras 9-12 (IMG_3032.JPG-IMG_3035.JPG): 28 matches
26% - Cameras 9-13 (IMG_3032.JPG-IMG_3036.JPG): 5 matches
27% - Cameras 1-14 (IMG_3024.JPG-IMG_3037.JPG): 3 matches
28% - Cameras 2-0 (IMG_3025.JPG-IMG_3023.JPG): 509 matches
29% - Cameras 2-1 (IMG_3025.JPG-IMG_3024.JPG): 1148 matches
30% - Cameras 2-3 (IMG_3025.JPG-IMG_3026.JPG): 1262 matches
30% - Cameras 2-4 (IMG_3025.JPG-IMG_3027.JPG): 622 matches
31% - Cameras 10-4 (IMG_3033.JPG-IMG_3027.JPG): 75 matches
31% - Cameras 2-5 (IMG_3025.JPG-IMG_3028.JPG): 118 matches
32% - Cameras 10-5 (IMG_3033.JPG-IMG_3028.JPG): 258 matches
32% - Cameras 2-6 (IMG_3025.JPG-IMG_3029.JPG): 50 matches
33% - Cameras 10-6 (IMG_3033.JPG-IMG_3029.JPG): 345 matches
33% - Cameras 2-7 (IMG_3025.JPG-IMG_3030.JPG): 38 matches
34% - Cameras 10-7 (IMG_3033.JPG-IMG_3030.JPG): 428 matches
35% - Cameras 10-8 (IMG_3033.JPG-IMG_3031.JPG): 600 matches
36% - Cameras 10-9 (IMG_3033.JPG-IMG_3032.JPG): 1328 matches
37% - Cameras 10-11 (IMG_3033.JPG-IMG_3034.JPG): 1175 matches
38% - Cameras 10-12 (IMG_3033.JPG-IMG_3035.JPG): 459 matches
39% - Cameras 10-13 (IMG_3033.JPG-IMG_3036.JPG): 38 matches
40% - Cameras 10-14 (IMG_3033.JPG-IMG_3037.JPG): 8 matches
41% - Cameras 3-0 (IMG_3026.JPG-IMG_3023.JPG): 192 matches
42% - Cameras 3-1 (IMG_3026.JPG-IMG_3024.JPG): 392 matches
43% - Cameras 3-2 (IMG_3026.JPG-IMG_3025.JPG): 1244 matches
44% - Cameras 11-4 (IMG_3034.JPG-IMG_3027.JPG): 94 matches
44% - Cameras 3-4 (IMG_3026.JPG-IMG_3027.JPG): 1549 matches
45% - Cameras 11-5 (IMG_3034.JPG-IMG_3028.JPG): 154 matches
45% - Cameras 3-5 (IMG_3026.JPG-IMG_3028.JPG): 740 matches
46% - Cameras 11-6 (IMG_3034.JPG-IMG_3029.JPG): 151 matches
46% - Cameras 3-6 (IMG_3026.JPG-IMG_3029.JPG): 244 matches
47% - Cameras 11-7 (IMG_3034.JPG-IMG_3030.JPG): 147 matches
47% - Cameras 3-7 (IMG_3026.JPG-IMG_3030.JPG): 87 matches
48% - Cameras 11-8 (IMG_3034.JPG-IMG_3031.JPG): 203 matches
49% - Cameras 11-9 (IMG_3034.JPG-IMG_3032.JPG): 470 matches
50% - Cameras 11-10 (IMG_3034.JPG-IMG_3033.JPG): 1098 matches
50% - Cameras 3-10 (IMG_3026.JPG-IMG_3033.JPG): 5 matches
50% - Cameras 11-12 (IMG_3034.JPG-IMG_3035.JPG): 1281 matches
51% - Cameras 11-13 (IMG_3034.JPG-IMG_3036.JPG): 483 matches
52% - Cameras 11-14 (IMG_3034.JPG-IMG_3037.JPG): 162 matches
55% - Cameras 4-0 (IMG_3027.JPG-IMG_3023.JPG): 76 matches
56% - Cameras 4-1 (IMG_3027.JPG-IMG_3024.JPG): 148 matches
57% - Cameras 4-2 (IMG_3027.JPG-IMG_3025.JPG): 616 matches
58% - Cameras 4-3 (IMG_3027.JPG-IMG_3026.JPG): 1625 matches
59% - Cameras 4-5 (IMG_3027.JPG-IMG_3028.JPG): 1376 matches
60% - Cameras 4-6 (IMG_3027.JPG-IMG_3029.JPG): 1055 matches
61% - Cameras 4-7 (IMG_3027.JPG-IMG_3030.JPG): 274 matches
62% - Cameras 4-8 (IMG_3027.JPG-IMG_3031.JPG): 136 matches
62% - Cameras 12-10 (IMG_3035.JPG-IMG_3033.JPG): 504 matches
63% - Cameras 4-9 (IMG_3027.JPG-IMG_3032.JPG): 126 matches
63% - Cameras 12-11 (IMG_3035.JPG-IMG_3034.JPG): 1304 matches
64% - Cameras 4-10 (IMG_3027.JPG-IMG_3033.JPG): 137 matches
64% - Cameras 12-13 (IMG_3035.JPG-IMG_3036.JPG): 1079 matches
65% - Cameras 4-11 (IMG_3027.JPG-IMG_3034.JPG): 113 matches
65% - Cameras 12-14 (IMG_3035.JPG-IMG_3037.JPG): 450 matches
70% - Cameras 5-1 (IMG_3028.JPG-IMG_3024.JPG): 10 matches
70% - Cameras 5-2 (IMG_3028.JPG-IMG_3025.JPG): 165 matches
71% - Cameras 5-3 (IMG_3028.JPG-IMG_3026.JPG): 823 matches
72% - Cameras 5-4 (IMG_3028.JPG-IMG_3027.JPG): 1408 matches
73% - Cameras 5-6 (IMG_3028.JPG-IMG_3029.JPG): 1789 matches
74% - Cameras 5-7 (IMG_3028.JPG-IMG_3030.JPG): 1077 matches
75% - Cameras 13-9 (IMG_3036.JPG-IMG_3032.JPG): 26 matches
75% - Cameras 5-8 (IMG_3028.JPG-IMG_3031.JPG): 371 matches
76% - Cameras 13-10 (IMG_3036.JPG-IMG_3033.JPG): 32 matches
76% - Cameras 5-9 (IMG_3028.JPG-IMG_3032.JPG): 285 matches
77% - Cameras 13-11 (IMG_3036.JPG-IMG_3034.JPG): 462 matches
77% - Cameras 5-10 (IMG_3028.JPG-IMG_3033.JPG): 305 matches
78% - Cameras 13-12 (IMG_3036.JPG-IMG_3035.JPG): 1107 matches
78% - Cameras 5-11 (IMG_3028.JPG-IMG_3034.JPG): 173 matches
79% - Cameras 13-14 (IMG_3036.JPG-IMG_3037.JPG): 1011 matches
83% - Cameras 6-1 (IMG_3029.JPG-IMG_3024.JPG): 12 matches
84% - Cameras 6-2 (IMG_3029.JPG-IMG_3025.JPG): 38 matches
85% - Cameras 6-3 (IMG_3029.JPG-IMG_3026.JPG): 333 matches
86% - Cameras 6-4 (IMG_3029.JPG-IMG_3027.JPG): 887 matches
87% - Cameras 6-5 (IMG_3029.JPG-IMG_3028.JPG): 1652 matches
88% - Cameras 6-7 (IMG_3029.JPG-IMG_3030.JPG): 1548 matches
89% - Cameras 14-10 (IMG_3037.JPG-IMG_3033.JPG): 3 matches
89% - Cameras 6-8 (IMG_3029.JPG-IMG_3031.JPG): 800 matches
90% - Cameras 14-11 (IMG_3037.JPG-IMG_3034.JPG): 153 matches
90% - Cameras 6-9 (IMG_3029.JPG-IMG_3032.JPG): 469 matches
90% - Cameras 14-12 (IMG_3037.JPG-IMG_3035.JPG): 422 matches
91% - Cameras 6-10 (IMG_3029.JPG-IMG_3033.JPG): 363 matches
91% - Cameras 14-13 (IMG_3037.JPG-IMG_3036.JPG): 982 matches
92% - Cameras 6-11 (IMG_3029.JPG-IMG_3034.JPG): 165 matches
95% - Cameras 7-3 (IMG_3030.JPG-IMG_3026.JPG): 99 matches
96% - Cameras 7-4 (IMG_3030.JPG-IMG_3027.JPG): 313 matches
96% - Cameras 7-5 (IMG_3030.JPG-IMG_3028.JPG): 978 matches
97% - Cameras 7-6 (IMG_3030.JPG-IMG_3029.JPG): 1555 matches
97% - Cameras 7-8 (IMG_3030.JPG-IMG_3031.JPG): 1210 matches
98% - Cameras 7-9 (IMG_3030.JPG-IMG_3032.JPG): 741 matches
98% - Cameras 7-10 (IMG_3030.JPG-IMG_3033.JPG): 434 matches
99% - Cameras 7-11 (IMG_3030.JPG-IMG_3034.JPG): 156 matches
Initial alignment from cameras #0 and #1 (IMG_3023.JPG, IMG_3024.JPG)
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 89% inliers with MSE=1.71016
    Camera #0 projections: 89% inliers (1037/1159) with MSE=1.68797
    Camera #1 projections: 89% inliers (1035/1159) with MSE=1.73239
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
After BA tie poits: 0% old + 11% new = 11% total outliers
After BA projections: 89% inliers with MSE=0.36941
    Camera #0 projections: 89% inliers (1027/1159) with MSE=0.374369
    Camera #1 projections: 89% inliers (1028/1159) with MSE=0.364456
Append camera #2 (IMG_3025.JPG) to alignment via 780 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 73% inliers with MSE=0.780135
    Camera #0 projections: 88% inliers (1168/1328) with MSE=0.467924
    Camera #1 projections: 82% inliers (1488/1813) with MSE=0.640142
    Camera #2 projections: 50% inliers (814/1634) with MSE=1.48403
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.76899, 0.0602982, 0.691543] -> [-1.94468, 0.023837, 0.589486]
After BA tie poits: 7% old + 8% new = 15% total outliers
After BA projections: 88% inliers with MSE=0.672545
    Camera #0 projections: 84% inliers (1111/1328) with MSE=0.995474
    Camera #1 projections: 88% inliers (1595/1813) with MSE=0.756994
    Camera #2 projections: 92% inliers (1500/1634) with MSE=0.343563
Append camera #3 (IMG_3026.JPG) to alignment via 953 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 64% inliers with MSE=0.803494
    Camera #0 projections: 83% inliers (1117/1340) with MSE=0.99925
    Camera #1 projections: 87% inliers (1622/1873) with MSE=0.769079
    Camera #2 projections: 72% inliers (1666/2317) with MSE=0.508409
    Camera #3 projections: 14% inliers (250/1734) with MSE=2.11858
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.94468, 0.023837, 0.589486] -> [-1.9087, 0.00956146, 0.50103]
Camera #3 center: [-2.522, 0.0400071, 1.21233] -> [-2.75186, 0.0160656, 0.92714]
After BA tie poits: 11% old + 5% new = 15% total outliers
After BA projections: 87% inliers with MSE=0.393073
    Camera #0 projections: 81% inliers (1082/1340) with MSE=0.999901
    Camera #1 projections: 84% inliers (1565/1873) with MSE=0.52148
    Camera #2 projections: 89% inliers (2055/2317) with MSE=0.168427
    Camera #3 projections: 92% inliers (1596/1734) with MSE=0.145016
Append camera #4 (IMG_3027.JPG) to alignment via 1123 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 87% inliers with MSE=0.648021
    Camera #0 projections: 81% inliers (1088/1346) with MSE=0.997276
    Camera #1 projections: 84% inliers (1572/1881) with MSE=0.525328
    Camera #2 projections: 88% inliers (2204/2496) with MSE=0.176716
    Camera #3 projections: 93% inliers (2396/2582) with MSE=0.201209
    Camera #4 projections: 84% inliers (1981/2352) with MSE=1.61834
After BA camera: k1=0, k2=0, f=1671.92, cx=321.042, cy=509.828
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.9087, 0.00956146, 0.50103] -> [-1.87091, 0.0183931, 0.525516]
Camera #3 center: [-2.75186, 0.0160656, 0.92714] -> [-2.66515, 0.0354134, 0.950741]
Camera #4 center: [-3.38874, 0.0494437, 1.51637] -> [-3.24282, 0.0769367, 1.53622]
After BA tie poits: 11% old + 6% new = 17% total outliers
After BA projections: 84% inliers with MSE=0.21032
    Camera #0 projections: 77% inliers (1034/1346) with MSE=0.398544
    Camera #1 projections: 81% inliers (1520/1881) with MSE=0.224298
    Camera #2 projections: 85% inliers (2120/2496) with MSE=0.155262
    Camera #3 projections: 90% inliers (2333/2582) with MSE=0.179439
    Camera #4 projections: 83% inliers (1954/2352) with MSE=0.19645
Append camera #5 (IMG_3028.JPG) to alignment via 1107 common points
Before BA camera: k1=0, k2=0, f=1671.92, cx=321.042, cy=509.828
Before BA projections: 79% inliers with MSE=0.511296
    Camera #0 projections: 77% inliers (1034/1346) with MSE=0.398544
    Camera #1 projections: 81% inliers (1520/1881) with MSE=0.224298
    Camera #2 projections: 85% inliers (2132/2511) with MSE=0.159677
    Camera #3 projections: 85% inliers (2392/2801) with MSE=0.19638
    Camera #4 projections: 79% inliers (2396/3023) with MSE=0.269481
    Camera #5 projections: 66% inliers (1360/2073) with MSE=2.4489
After BA camera: k1=0, k2=0, f=1669.45, cx=326.612, cy=517.729
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87091, 0.0183931, 0.525516] -> [-1.87429, 0.0173118, 0.52511]
Camera #3 center: [-2.66515, 0.0354134, 0.950741] -> [-2.65772, 0.0323484, 0.941457]
Camera #4 center: [-3.24282, 0.0769367, 1.53622] -> [-3.22779, 0.0702901, 1.51397]
Camera #5 center: [-3.74026, 0.066085, 2.23511] -> [-3.73507, 0.116, 2.22101]
After BA tie poits: 13% old + 4% new = 17% total outliers
After BA projections: 83% inliers with MSE=0.216921
    Camera #0 projections: 76% inliers (1021/1346) with MSE=0.421447
    Camera #1 projections: 80% inliers (1498/1881) with MSE=0.233811
    Camera #2 projections: 83% inliers (2083/2511) with MSE=0.152199
    Camera #3 projections: 86% inliers (2396/2801) with MSE=0.175984
    Camera #4 projections: 83% inliers (2505/3023) with MSE=0.199087
    Camera #5 projections: 87% inliers (1812/2073) with MSE=0.2409
Append camera #6 (IMG_3029.JPG) to alignment via 1311 common points
Before BA camera: k1=0, k2=0, f=1669.45, cx=326.612, cy=517.729
Before BA projections: 82% inliers with MSE=0.504264
    Camera #0 projections: 76% inliers (1021/1346) with MSE=0.421447
    Camera #1 projections: 80% inliers (1501/1885) with MSE=0.233502
    Camera #2 projections: 83% inliers (2084/2512) with MSE=0.152164
    Camera #3 projections: 85% inliers (2415/2829) with MSE=0.176222
    Camera #4 projections: 82% inliers (2694/3276) with MSE=0.359785
    Camera #5 projections: 84% inliers (2478/2957) with MSE=0.587851
    Camera #6 projections: 77% inliers (1989/2591) with MSE=1.60988
After BA camera: k1=0.00178518, k2=-0.067329, f=1629.76, cx=335.913, cy=534.27
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87429, 0.0173118, 0.52511] -> [-1.8785, 0.0147732, 0.514223]
Camera #3 center: [-2.65772, 0.0323484, 0.941457] -> [-2.67787, 0.0276249, 0.928248]
Camera #4 center: [-3.22779, 0.0702901, 1.51397] -> [-3.26674, 0.0630396, 1.49864]
Camera #5 center: [-3.73507, 0.116, 2.22101] -> [-3.78841, 0.105216, 2.19523]
Camera #6 center: [-3.94732, 0.182194, 3.07298] -> [-4.01852, 0.180079, 3.02656]
After BA tie poits: 14% old + 4% new = 18% total outliers
After BA projections: 82% inliers with MSE=0.185714
    Camera #0 projections: 75% inliers (1013/1346) with MSE=0.494089
    Camera #1 projections: 79% inliers (1482/1885) with MSE=0.250033
    Camera #2 projections: 82% inliers (2050/2512) with MSE=0.119654
    Camera #3 projections: 82% inliers (2318/2829) with MSE=0.121706
    Camera #4 projections: 80% inliers (2622/3276) with MSE=0.172883
    Camera #5 projections: 85% inliers (2517/2957) with MSE=0.156815
    Camera #6 projections: 87% inliers (2261/2591) with MSE=0.177959
Append camera #7 (IMG_3030.JPG) to alignment via 1592 common points
Before BA camera: k1=0.00178518, k2=-0.067329, f=1629.76, cx=335.913, cy=534.27
Before BA projections: 83% inliers with MSE=0.354015
    Camera #0 projections: 75% inliers (1013/1346) with MSE=0.494089
    Camera #1 projections: 79% inliers (1482/1885) with MSE=0.250033
    Camera #2 projections: 82% inliers (2050/2512) with MSE=0.119654
    Camera #3 projections: 82% inliers (2322/2833) with MSE=0.121927
    Camera #4 projections: 80% inliers (2644/3305) with MSE=0.179527
    Camera #5 projections: 85% inliers (2713/3180) with MSE=0.174355
    Camera #6 projections: 88% inliers (2869/3256) with MSE=0.203703
    Camera #7 projections: 88% inliers (2276/2577) with MSE=1.41358
After BA camera: k1=-0.00249033, k2=0.0419433, f=1573.81, cx=339.132, cy=550.862
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.8785, 0.0147732, 0.514223] -> [-1.87708, 0.0131969, 0.509793]
Camera #3 center: [-2.67787, 0.0276249, 0.928248] -> [-2.67518, 0.0240664, 0.915972]
Camera #4 center: [-3.26674, 0.0630396, 1.49864] -> [-3.26456, 0.0564863, 1.4779]
Camera #5 center: [-3.78841, 0.105216, 2.19523] -> [-3.79315, 0.0952011, 2.16708]
Camera #6 center: [-4.01852, 0.180079, 3.02656] -> [-4.03334, 0.164886, 2.99661]
Camera #7 center: [-4.16923, 0.25429, 3.94088] -> [-4.19437, 0.240326, 3.91129]
After BA tie poits: 16% old + 3% new = 19% total outliers
After BA projections: 80% inliers with MSE=0.17543
    Camera #0 projections: 72% inliers (975/1346) with MSE=0.559999
    Camera #1 projections: 76% inliers (1442/1885) with MSE=0.279528
    Camera #2 projections: 79% inliers (1993/2512) with MSE=0.114262
    Camera #3 projections: 79% inliers (2232/2833) with MSE=0.107176
    Camera #4 projections: 75% inliers (2494/3305) with MSE=0.138308
    Camera #5 projections: 81% inliers (2562/3180) with MSE=0.157592
    Camera #6 projections: 84% inliers (2720/3256) with MSE=0.151296
    Camera #7 projections: 89% inliers (2289/2577) with MSE=0.154946
Append camera #8 (IMG_3031.JPG) to alignment via 1472 common points
Before BA camera: k1=-0.00249033, k2=0.0419433, f=1573.81, cx=339.132, cy=550.862
Before BA projections: 81% inliers with MSE=0.271949
    Camera #0 projections: 72% inliers (975/1346) with MSE=0.559999
    Camera #1 projections: 76% inliers (1442/1885) with MSE=0.279528
    Camera #2 projections: 79% inliers (1993/2512) with MSE=0.114262
    Camera #3 projections: 79% inliers (2233/2834) with MSE=0.107137
    Camera #4 projections: 75% inliers (2506/3321) with MSE=0.140623
    Camera #5 projections: 80% inliers (2585/3214) with MSE=0.161541
    Camera #6 projections: 84% inliers (2930/3483) with MSE=0.160509
    Camera #7 projections: 90% inliers (2762/3083) with MSE=0.145643
    Camera #8 projections: 89% inliers (2057/2315) with MSE=1.08887
After BA camera: k1=-0.00187755, k2=0.00823483, f=1581.74, cx=341.739, cy=550.981
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87708, 0.0131969, 0.509793] -> [-1.87734, 0.0122391, 0.506928]
Camera #3 center: [-2.67518, 0.0240664, 0.915972] -> [-2.67793, 0.0219501, 0.912359]
Camera #4 center: [-3.26456, 0.0564863, 1.4779] -> [-3.27004, 0.0533422, 1.47319]
Camera #5 center: [-3.79315, 0.0952011, 2.16708] -> [-3.8004, 0.090988, 2.16218]
Camera #6 center: [-4.03334, 0.164886, 2.99661] -> [-4.04455, 0.160079, 2.99153]
Camera #7 center: [-4.19437, 0.240326, 3.91129] -> [-4.20819, 0.233668, 3.9057]
Camera #8 center: [-3.92736, 0.316549, 4.93492] -> [-3.93631, 0.309126, 4.94388]
After BA tie poits: 17% old + 3% new = 20% total outliers
After BA projections: 78% inliers with MSE=0.184243
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.571084
    Camera #1 projections: 75% inliers (1416/1885) with MSE=0.293899
    Camera #2 projections: 78% inliers (1962/2512) with MSE=0.114508
    Camera #3 projections: 77% inliers (2178/2834) with MSE=0.103639
    Camera #4 projections: 73% inliers (2417/3321) with MSE=0.150377
    Camera #5 projections: 76% inliers (2455/3214) with MSE=0.156191
    Camera #6 projections: 79% inliers (2745/3483) with MSE=0.143828
    Camera #7 projections: 85% inliers (2607/3083) with MSE=0.188953
    Camera #8 projections: 88% inliers (2038/2315) with MSE=0.19882
Append camera #9 (IMG_3032.JPG) to alignment via 1503 common points
Before BA camera: k1=-0.00187755, k2=0.00823483, f=1581.74, cx=341.739, cy=550.981
Before BA projections: 80% inliers with MSE=0.352413
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.571084
    Camera #1 projections: 75% inliers (1416/1885) with MSE=0.293899
    Camera #2 projections: 78% inliers (1962/2512) with MSE=0.114508
    Camera #3 projections: 77% inliers (2178/2834) with MSE=0.103639
    Camera #4 projections: 73% inliers (2419/3324) with MSE=0.150885
    Camera #5 projections: 76% inliers (2466/3229) with MSE=0.156599
    Camera #6 projections: 79% inliers (2766/3509) with MSE=0.145868
    Camera #7 projections: 84% inliers (2719/3223) with MSE=0.221425
    Camera #8 projections: 90% inliers (2859/3168) with MSE=0.43811
    Camera #9 projections: 86% inliers (2239/2589) with MSE=1.48296
After BA camera: k1=-0.00523802, k2=-0.0156613, f=1635.05, cx=345.524, cy=550.92
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87734, 0.0122391, 0.506928] -> [-1.8788, 0.0110754, 0.507641]
Camera #3 center: [-2.67793, 0.0219501, 0.912359] -> [-2.67719, 0.0184665, 0.914875]
Camera #4 center: [-3.27004, 0.0533422, 1.47319] -> [-3.26642, 0.0472695, 1.47567]
Camera #5 center: [-3.8004, 0.090988, 2.16218] -> [-3.79097, 0.0810512, 2.1631]
Camera #6 center: [-4.04455, 0.160079, 2.99153] -> [-4.03105, 0.145831, 2.98524]
Camera #7 center: [-4.20819, 0.233668, 3.9057] -> [-4.19201, 0.213677, 3.88783]
Camera #8 center: [-3.93631, 0.309126, 4.94388] -> [-3.92991, 0.281384, 4.89445]
Camera #9 center: [-3.55046, 0.355219, 5.87498] -> [-3.55519, 0.328854, 5.86667]
After BA tie poits: 18% old + 2% new = 20% total outliers
After BA projections: 77% inliers with MSE=0.165807
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.578535
    Camera #1 projections: 75% inliers (1412/1885) with MSE=0.286681
    Camera #2 projections: 77% inliers (1931/2512) with MSE=0.121529
    Camera #3 projections: 75% inliers (2139/2834) with MSE=0.107391
    Camera #4 projections: 71% inliers (2349/3324) with MSE=0.144102
    Camera #5 projections: 73% inliers (2353/3229) with MSE=0.147611
    Camera #6 projections: 75% inliers (2615/3509) with MSE=0.115214
    Camera #7 projections: 78% inliers (2507/3223) with MSE=0.114494
    Camera #8 projections: 85% inliers (2689/3168) with MSE=0.147024
    Camera #9 projections: 90% inliers (2333/2589) with MSE=0.184248
Append camera #10 (IMG_3033.JPG) to alignment via 1619 common points
Before BA camera: k1=-0.00523802, k2=-0.0156613, f=1635.05, cx=345.524, cy=550.92
Before BA projections: 78% inliers with MSE=0.359903
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.578535
    Camera #1 projections: 75% inliers (1412/1885) with MSE=0.286681
    Camera #2 projections: 77% inliers (1931/2512) with MSE=0.121529
    Camera #3 projections: 75% inliers (2139/2834) with MSE=0.107391
    Camera #4 projections: 71% inliers (2357/3333) with MSE=0.145002
    Camera #5 projections: 73% inliers (2371/3249) with MSE=0.147166
    Camera #6 projections: 75% inliers (2627/3525) with MSE=0.116282
    Camera #7 projections: 78% inliers (2521/3238) with MSE=0.114343
    Camera #8 projections: 85% inliers (2742/3228) with MSE=0.154988
    Camera #9 projections: 91% inliers (2958/3246) with MSE=0.264343
    Camera #10 projections: 80% inliers (1958/2441) with MSE=2.40555
After BA camera: k1=-0.00339271, k2=0.00249677, f=1620.08, cx=345.154, cy=553.599
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.8788, 0.0110754, 0.507641] -> [-1.87682, 0.0109091, 0.507038]
Camera #3 center: [-2.67719, 0.0184665, 0.914875] -> [-2.67665, 0.0183745, 0.914819]
Camera #4 center: [-3.26642, 0.0472695, 1.47567] -> [-3.26674, 0.0473211, 1.47797]
Camera #5 center: [-3.79097, 0.0810512, 2.1631] -> [-3.79244, 0.0814704, 2.16923]
Camera #6 center: [-4.03105, 0.145831, 2.98524] -> [-4.03181, 0.14682, 2.99726]
Camera #7 center: [-4.19201, 0.213677, 3.88783] -> [-4.18931, 0.215625, 3.90784]
Camera #8 center: [-3.92991, 0.281384, 4.89445] -> [-3.91646, 0.284639, 4.92686]
Camera #9 center: [-3.55519, 0.328854, 5.86667] -> [-3.56453, 0.328315, 5.84312]
Camera #10 center: [-2.83944, 0.399737, 6.61977] -> [-2.88012, 0.393387, 6.61468]
After BA tie poits: 18% old + 3% new = 21% total outliers
After BA projections: 78% inliers with MSE=0.199235
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.585035
    Camera #1 projections: 75% inliers (1413/1885) with MSE=0.29395
    Camera #2 projections: 77% inliers (1926/2512) with MSE=0.116296
    Camera #3 projections: 75% inliers (2132/2834) with MSE=0.112449
    Camera #4 projections: 70% inliers (2346/3333) with MSE=0.152395
    Camera #5 projections: 72% inliers (2351/3249) with MSE=0.166177
    Camera #6 projections: 74% inliers (2613/3525) with MSE=0.17106
    Camera #7 projections: 77% inliers (2490/3238) with MSE=0.177312
    Camera #8 projections: 84% inliers (2707/3228) with MSE=0.199575
    Camera #9 projections: 90% inliers (2911/3246) with MSE=0.252825
    Camera #10 projections: 91% inliers (2220/2441) with MSE=0.196555
Append camera #11 (IMG_3034.JPG) to alignment via 964 common points
Before BA camera: k1=-0.00339271, k2=0.00249677, f=1620.08, cx=345.154, cy=553.599
Before BA projections: 77% inliers with MSE=0.261394
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.585035
    Camera #1 projections: 75% inliers (1413/1885) with MSE=0.29395
    Camera #2 projections: 77% inliers (1926/2512) with MSE=0.116296
    Camera #3 projections: 75% inliers (2132/2834) with MSE=0.112449
    Camera #4 projections: 70% inliers (2351/3339) with MSE=0.152345
    Camera #5 projections: 72% inliers (2356/3255) with MSE=0.166188
    Camera #6 projections: 74% inliers (2617/3530) with MSE=0.171196
    Camera #7 projections: 77% inliers (2492/3242) with MSE=0.177181
    Camera #8 projections: 84% inliers (2709/3230) with MSE=0.199822
    Camera #9 projections: 88% inliers (2944/3356) with MSE=0.270074
    Camera #10 projections: 85% inliers (2549/2983) with MSE=0.249978
    Camera #11 projections: 75% inliers (1257/1681) with MSE=1.32163
After BA camera: k1=-0.00302505, k2=-0.00707019, f=1622.21, cx=346.014, cy=553.868
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87682, 0.0109091, 0.507038] -> [-1.87738, 0.0107434, 0.506675]
Camera #3 center: [-2.67665, 0.0183745, 0.914819] -> [-2.67641, 0.0180194, 0.913675]
Camera #4 center: [-3.26674, 0.0473211, 1.47797] -> [-3.26679, 0.0464342, 1.4751]
Camera #5 center: [-3.79244, 0.0814704, 2.16923] -> [-3.79265, 0.0800055, 2.16476]
Camera #6 center: [-4.03181, 0.14682, 2.99726] -> [-4.0332, 0.144717, 2.99154]
Camera #7 center: [-4.18931, 0.215625, 3.90784] -> [-4.19216, 0.212874, 3.9008]
Camera #8 center: [-3.91646, 0.284639, 4.92686] -> [-3.92176, 0.281502, 4.91999]
Camera #9 center: [-3.56453, 0.328315, 5.84312] -> [-3.57077, 0.325027, 5.84004]
Camera #10 center: [-2.88012, 0.393387, 6.61468] -> [-2.89027, 0.389527, 6.60706]
Camera #11 center: [-2.21548, 0.425717, 7.1475] -> [-2.2372, 0.43573, 7.12543]
After BA tie poits: 19% old + 2% new = 22% total outliers
After BA projections: 79% inliers with MSE=0.236577
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.59253
    Camera #1 projections: 75% inliers (1413/1885) with MSE=0.29713
    Camera #2 projections: 77% inliers (1926/2512) with MSE=0.119519
    Camera #3 projections: 75% inliers (2131/2834) with MSE=0.130404
    Camera #4 projections: 70% inliers (2345/3339) with MSE=0.215526
    Camera #5 projections: 72% inliers (2353/3255) with MSE=0.214362
    Camera #6 projections: 74% inliers (2611/3530) with MSE=0.215792
    Camera #7 projections: 77% inliers (2481/3242) with MSE=0.227501
    Camera #8 projections: 83% inliers (2691/3230) with MSE=0.25924
    Camera #9 projections: 88% inliers (2962/3356) with MSE=0.313494
    Camera #10 projections: 91% inliers (2711/2983) with MSE=0.256487
    Camera #11 projections: 90% inliers (1508/1681) with MSE=0.140477
Append camera #12 (IMG_3035.JPG) to alignment via 410 common points
Before BA camera: k1=-0.00302505, k2=-0.00707019, f=1622.21, cx=346.014, cy=553.868
Before BA projections: 80% inliers with MSE=0.309794
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.59253
    Camera #1 projections: 75% inliers (1413/1885) with MSE=0.29713
    Camera #2 projections: 77% inliers (1926/2512) with MSE=0.119519
    Camera #3 projections: 75% inliers (2131/2834) with MSE=0.130404
    Camera #4 projections: 70% inliers (2345/3339) with MSE=0.215526
    Camera #5 projections: 72% inliers (2353/3255) with MSE=0.214362
    Camera #6 projections: 74% inliers (2611/3530) with MSE=0.215792
    Camera #7 projections: 77% inliers (2481/3242) with MSE=0.227501
    Camera #8 projections: 83% inliers (2691/3230) with MSE=0.25924
    Camera #9 projections: 88% inliers (2962/3356) with MSE=0.313494
    Camera #10 projections: 92% inliers (3020/3300) with MSE=0.362523
    Camera #11 projections: 91% inliers (2384/2625) with MSE=0.386156
    Camera #12 projections: 85% inliers (1499/1756) with MSE=1.09049
After BA camera: k1=-0.00569116, k2=0.0433186, f=1617.56, cx=347.248, cy=558.392
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87738, 0.0107434, 0.506675] -> [-1.87645, 0.00996899, 0.505853]
Camera #3 center: [-2.67641, 0.0180194, 0.913675] -> [-2.6761, 0.0161617, 0.912785]
Camera #4 center: [-3.26679, 0.0464342, 1.4751] -> [-3.26636, 0.0433077, 1.47467]
Camera #5 center: [-3.79265, 0.0800055, 2.16476] -> [-3.79212, 0.0752099, 2.16467]
Camera #6 center: [-4.0332, 0.144717, 2.99154] -> [-4.03247, 0.137822, 2.99168]
Camera #7 center: [-4.19216, 0.212874, 3.9008] -> [-4.19062, 0.203677, 3.9009]
Camera #8 center: [-3.92176, 0.281502, 4.91999] -> [-3.9196, 0.269402, 4.91938]
Camera #9 center: [-3.57077, 0.325027, 5.84004] -> [-3.56809, 0.310403, 5.83782]
Camera #10 center: [-2.89027, 0.389527, 6.60706] -> [-2.88828, 0.372676, 6.60334]
Camera #11 center: [-2.2372, 0.43573, 7.12543] -> [-2.23544, 0.416927, 7.11954]
Camera #12 center: [-1.44517, 0.496105, 7.61439] -> [-1.47606, 0.471788, 7.5825]
After BA tie poits: 19% old + 1% new = 20% total outliers
After BA projections: 72% inliers with MSE=0.143232
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.614688
    Camera #1 projections: 75% inliers (1411/1885) with MSE=0.301516
    Camera #2 projections: 77% inliers (1923/2512) with MSE=0.112824
    Camera #3 projections: 74% inliers (2089/2834) with MSE=0.0943277
    Camera #4 projections: 66% inliers (2220/3339) with MSE=0.12904
    Camera #5 projections: 66% inliers (2136/3255) with MSE=0.117061
    Camera #6 projections: 67% inliers (2373/3530) with MSE=0.129655
    Camera #7 projections: 65% inliers (2117/3242) with MSE=0.107446
    Camera #8 projections: 70% inliers (2251/3230) with MSE=0.0904081
    Camera #9 projections: 73% inliers (2441/3356) with MSE=0.113204
    Camera #10 projections: 74% inliers (2452/3300) with MSE=0.121899
    Camera #11 projections: 82% inliers (2149/2625) with MSE=0.132611
    Camera #12 projections: 88% inliers (1554/1756) with MSE=0.105156
Append camera #13 (IMG_3036.JPG) to alignment via 496 common points
Before BA camera: k1=-0.00569116, k2=0.0433186, f=1617.56, cx=347.248, cy=558.392
Before BA projections: 73% inliers with MSE=0.248186
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.614688
    Camera #1 projections: 75% inliers (1411/1885) with MSE=0.301516
    Camera #2 projections: 77% inliers (1923/2512) with MSE=0.112824
    Camera #3 projections: 74% inliers (2089/2834) with MSE=0.0943277
    Camera #4 projections: 66% inliers (2220/3339) with MSE=0.12904
    Camera #5 projections: 66% inliers (2136/3255) with MSE=0.117061
    Camera #6 projections: 67% inliers (2373/3530) with MSE=0.129655
    Camera #7 projections: 65% inliers (2117/3242) with MSE=0.107446
    Camera #8 projections: 70% inliers (2251/3230) with MSE=0.0904081
    Camera #9 projections: 73% inliers (2443/3359) with MSE=0.113491
    Camera #10 projections: 74% inliers (2453/3301) with MSE=0.122273
    Camera #11 projections: 82% inliers (2357/2876) with MSE=0.220548
    Camera #12 projections: 88% inliers (2158/2452) with MSE=0.383412
    Camera #13 projections: 79% inliers (1237/1572) with MSE=1.89709
After BA camera: k1=-0.00731663, k2=0.0788472, f=1589.03, cx=347.974, cy=563.998
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87645, 0.00996899, 0.505853] -> [-1.87683, 0.00978671, 0.504502]
Camera #3 center: [-2.6761, 0.0161617, 0.912785] -> [-2.67757, 0.0158268, 0.90957]
Camera #4 center: [-3.26636, 0.0433077, 1.47467] -> [-3.2689, 0.0425455, 1.4695]
Camera #5 center: [-3.79212, 0.0752099, 2.16467] -> [-3.79674, 0.0739016, 2.1568]
Camera #6 center: [-4.03247, 0.137822, 2.99168] -> [-4.0404, 0.135085, 2.98198]
Camera #7 center: [-4.19062, 0.203677, 3.9009] -> [-4.20307, 0.19981, 3.88967]
Camera #8 center: [-3.9196, 0.269402, 4.91938] -> [-3.93804, 0.263652, 4.90946]
Camera #9 center: [-3.56809, 0.310403, 5.83782] -> [-3.592, 0.303612, 5.83084]
Camera #10 center: [-2.88828, 0.372676, 6.60334] -> [-2.9191, 0.364545, 6.59937]
Camera #11 center: [-2.23544, 0.416927, 7.11954] -> [-2.27645, 0.407691, 7.11671]
Camera #12 center: [-1.47606, 0.471788, 7.5825] -> [-1.50242, 0.463862, 7.5944]
Camera #13 center: [-0.606444, 0.491335, 7.83746] -> [-0.662991, 0.473019, 7.84952]
After BA tie poits: 19% old + 2% new = 21% total outliers
After BA projections: 72% inliers with MSE=0.157609
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.644181
    Camera #1 projections: 75% inliers (1410/1885) with MSE=0.310116
    Camera #2 projections: 77% inliers (1922/2512) with MSE=0.107271
    Camera #3 projections: 74% inliers (2087/2834) with MSE=0.0896755
    Camera #4 projections: 66% inliers (2216/3339) with MSE=0.116477
    Camera #5 projections: 66% inliers (2136/3255) with MSE=0.113937
    Camera #6 projections: 66% inliers (2347/3530) with MSE=0.106852
    Camera #7 projections: 66% inliers (2127/3242) with MSE=0.135394
    Camera #8 projections: 70% inliers (2251/3230) with MSE=0.134298
    Camera #9 projections: 73% inliers (2444/3359) with MSE=0.150702
    Camera #10 projections: 74% inliers (2437/3301) with MSE=0.15097
    Camera #11 projections: 80% inliers (2294/2876) with MSE=0.152612
    Camera #12 projections: 88% inliers (2150/2452) with MSE=0.152682
    Camera #13 projections: 78% inliers (1225/1572) with MSE=0.164121
Append camera #14 (IMG_3037.JPG) to alignment via 785 common points
Before BA camera: k1=-0.00731663, k2=0.0788472, f=1589.03, cx=347.974, cy=563.998
Before BA projections: 72% inliers with MSE=0.211045
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.644181
    Camera #1 projections: 75% inliers (1410/1885) with MSE=0.310116
    Camera #2 projections: 77% inliers (1922/2512) with MSE=0.107271
    Camera #3 projections: 74% inliers (2087/2834) with MSE=0.0896755
    Camera #4 projections: 66% inliers (2216/3339) with MSE=0.116477
    Camera #5 projections: 66% inliers (2136/3255) with MSE=0.113937
    Camera #6 projections: 66% inliers (2347/3530) with MSE=0.106852
    Camera #7 projections: 66% inliers (2127/3242) with MSE=0.135394
    Camera #8 projections: 70% inliers (2251/3230) with MSE=0.134298
    Camera #9 projections: 73% inliers (2444/3359) with MSE=0.150702
    Camera #10 projections: 74% inliers (2437/3303) with MSE=0.15097
    Camera #11 projections: 80% inliers (2306/2895) with MSE=0.15555
    Camera #12 projections: 88% inliers (2206/2520) with MSE=0.158893
    Camera #13 projections: 79% inliers (1649/2096) with MSE=0.339154
    Camera #14 projections: 61% inliers (867/1417) with MSE=1.60899
After BA camera: k1=-0.00598777, k2=0.0710756, f=1586.56, cx=348.053, cy=564.459
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87683, 0.00978671, 0.504502] -> [-1.87652, 0.00968518, 0.504261]
Camera #3 center: [-2.67757, 0.0158268, 0.90957] -> [-2.67689, 0.0158108, 0.908964]
Camera #4 center: [-3.2689, 0.0425455, 1.4695] -> [-3.26819, 0.0424748, 1.46859]
Camera #5 center: [-3.79674, 0.0739016, 2.1568] -> [-3.79612, 0.0738377, 2.15561]
Camera #6 center: [-4.0404, 0.135085, 2.98198] -> [-4.03995, 0.134972, 2.98076]
Camera #7 center: [-4.20307, 0.19981, 3.88967] -> [-4.2028, 0.199667, 3.88868]
Camera #8 center: [-3.93804, 0.263652, 4.90946] -> [-3.93776, 0.263386, 4.90891]
Camera #9 center: [-3.592, 0.303612, 5.83084] -> [-3.5918, 0.303196, 5.83012]
Camera #10 center: [-2.9191, 0.364545, 6.59937] -> [-2.91982, 0.363803, 6.59774]
Camera #11 center: [-2.27645, 0.407691, 7.11671] -> [-2.2779, 0.406588, 7.11516]
Camera #12 center: [-1.50242, 0.463862, 7.5944] -> [-1.51204, 0.460654, 7.58929]
Camera #13 center: [-0.662991, 0.473019, 7.84952] -> [-0.671646, 0.46878, 7.84297]
Camera #14 center: [0.0912784, 0.499574, 7.92727] -> [0.0673824, 0.483656, 7.99196]
After BA tie poits: 20% old + 1% new = 21% total outliers
After BA projections: 73% inliers with MSE=0.157451
    Camera #0 projections: 72% inliers (974/1346) with MSE=0.645981
    Camera #1 projections: 75% inliers (1410/1885) with MSE=0.311594
    Camera #2 projections: 77% inliers (1922/2512) with MSE=0.105861
    Camera #3 projections: 74% inliers (2087/2834) with MSE=0.0891224
    Camera #4 projections: 66% inliers (2216/3339) with MSE=0.116093
    Camera #5 projections: 66% inliers (2136/3255) with MSE=0.113011
    Camera #6 projections: 66% inliers (2347/3530) with MSE=0.104692
    Camera #7 projections: 65% inliers (2119/3242) with MSE=0.124235
    Camera #8 projections: 70% inliers (2251/3230) with MSE=0.132633
    Camera #9 projections: 73% inliers (2447/3359) with MSE=0.161419
    Camera #10 projections: 74% inliers (2435/3303) with MSE=0.158919
    Camera #11 projections: 79% inliers (2297/2895) with MSE=0.154688
    Camera #12 projections: 85% inliers (2145/2520) with MSE=0.135228
    Camera #13 projections: 82% inliers (1714/2096) with MSE=0.171097
    Camera #14 projections: 91% inliers (1284/1417) with MSE=0.15946
[       OK ] SFM.ReconstructNViews (67819 ms)
[----------] 1 test from SFM (67819 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (67819 ms total)
[  PASSED  ] 1 test.
...
</pre>

</p></details>
